### PR TITLE
feat: CRUD operations, command execution, and export/import

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,4 @@
-# Include any files or directories that you don't want to be copied to your
-# container here (e.g., local build artifacts, temporary files, etc.).
-#
-# For more help, visit the .dockerignore file reference guide at
+# Docker build context exclusions
 # https://docs.docker.com/engine/reference/builder/#dockerignore-file
 
 **/.DS_Store
@@ -32,14 +29,9 @@
 **/values.dev.yaml
 LICENSE
 README.md
-ui/node_modules/
-ui/build/
-.git/
+*.md
+*.code-workspace
 .claude/
 .coordination/
-.vscode/
 docs/
-*.md
-!ui/README.md
-LICENSE
-*.code-workspace
+ui/build/

--- a/docs/decisions/ADR-005-storage-backend.md
+++ b/docs/decisions/ADR-005-storage-backend.md
@@ -1,0 +1,85 @@
+# ADR-005: Storage Backend — localStorage with Export/Import
+
+**Date:** 2026-02-16
+**Status:** Accepted
+**Deciders:** Herb Hall, Claude (AI assistant)
+
+## Context
+
+Runbooks needs persistent storage for user-created command scripts. ADR-003 established a frontend-only architecture (no backend VM service). We need to choose a storage mechanism that works within this constraint.
+
+## Options Considered
+
+### 1. Browser localStorage
+
+- **How:** `window.localStorage.setItem("runbooks", JSON.stringify(data))`
+- **Pros:** Zero infrastructure, instant read/write, works today
+- **Cons:** Data lost on extension reinstall/update; ~5-10MB limit (plenty for runbooks); no cross-device sync
+
+### 2. Docker volume via CLI exec
+
+- **How:** Spawn Alpine containers to read/write a JSON file on a Docker volume using `ddClient.docker.cli.exec()`
+- **Pros:** Persists across extension reinstalls; uses standard Docker primitives
+- **Cons:** Spawns a container for every read/write (slow, ~1-2s per operation); fragile; visible in container logs
+
+### 3. Add a backend service (revise ADR-003)
+
+- **How:** Add a Go/Node HTTP server in `docker-compose.yaml` with a persistent volume; frontend calls REST API
+- **Pros:** Most robust; standard pattern used by all official samples that persist data
+- **Cons:** Contradicts ADR-003; adds build complexity (multi-arch binary); heavier image
+
+### 4. Host binaries
+
+- **How:** Bundle platform-specific scripts that write to `~/.runbooks/`; invoke via `ddClient.extension.host`
+- **Pros:** Persists on host filesystem; fast I/O
+- **Cons:** Must maintain Windows/macOS/Linux scripts; adds host binary packaging to Dockerfile
+
+## Decision
+
+**localStorage for MVP**, with export/import to mitigate data loss risk.
+
+Rationale:
+
+1. **Runbook data is small** — A user with 50 runbooks produces maybe 20KB of JSON. Well within localStorage limits.
+2. **Speed to working CRUD** — No infrastructure changes needed. Wire up React state + localStorage today.
+3. **Export/Import covers the gap** — Users can export runbooks as a JSON file and re-import after an extension update. This is explicit and transparent.
+4. **Backend can come later** — If the extension grows to need sync, sharing, or large-scale storage, ADR-003 can be revisited. localStorage is easy to migrate from.
+
+## Implementation Plan
+
+```typescript
+// Storage key
+const STORAGE_KEY = "runbooks-data";
+
+// Save
+localStorage.setItem(STORAGE_KEY, JSON.stringify(runbooks));
+
+// Load
+const data = localStorage.getItem(STORAGE_KEY);
+const runbooks = data ? JSON.parse(data) : [];
+
+// Export (download as file)
+const blob = new Blob([JSON.stringify(runbooks, null, 2)], { type: "application/json" });
+
+// Import (file upload + parse)
+const reader = new FileReader();
+reader.onload = (e) => setRunbooks(JSON.parse(e.target.result));
+```
+
+## Trade-offs
+
+**Accepted risks:**
+
+- Data lost on extension reinstall without prior export (mitigated by export/import UX)
+- No cross-device sync (acceptable for a local tool)
+- localStorage is per-extension-context in Docker Desktop (no collision with other extensions)
+
+**Upgrade path:**
+
+- If a backend is added later, migrate by reading localStorage on first launch, posting to backend API, then clearing localStorage. One-time migration, no data loss.
+
+## Consequences
+
+- ADR-003 (frontend-only) remains valid
+- Must implement export/import early to prevent user frustration
+- Storage abstraction layer recommended so swapping backends later is easy

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,16 +1,14 @@
+import { useState, useRef } from "react";
 import { createDockerDesktopClient } from "@docker/extension-api-client";
-import {
-  Box,
-  Typography,
-  Stack,
-  Button,
-} from "@mui/material";
+import { Box, Typography, Stack, Button } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
+import DownloadIcon from "@mui/icons-material/Download";
+import UploadIcon from "@mui/icons-material/Upload";
 import { RunbookList } from "./components/RunbookList";
+import { RunbookFormDialog } from "./components/RunbookFormDialog";
+import { useRunbooks } from "./context/RunbookContext";
+import { exportRunbooks, importRunbooks } from "./storage";
 
-// Initialize the Docker Desktop extension client.
-// This gives us access to docker.cli.exec() for running commands
-// and docker.desktopUI for toast notifications.
 const ddClient = createDockerDesktopClient();
 
 export function useDockerDesktopClient() {
@@ -18,6 +16,32 @@ export function useDockerDesktopClient() {
 }
 
 export default function App() {
+  const { runbooks, replaceAll } = useRunbooks();
+  const [formOpen, setFormOpen] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleExport = () => {
+    exportRunbooks(runbooks);
+    ddClient.desktopUI.toast.success("Runbooks exported");
+  };
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const imported = await importRunbooks(file);
+      replaceAll(imported);
+      ddClient.desktopUI.toast.success(`Imported ${imported.length} runbooks`);
+    } catch (err) {
+      ddClient.desktopUI.toast.error(err instanceof Error ? err.message : "Import failed");
+    }
+    e.target.value = "";
+  };
+
   return (
     <Box sx={{ p: 3, height: "100vh", display: "flex", flexDirection: "column" }}>
       <Stack
@@ -27,9 +51,19 @@ export default function App() {
         sx={{ mb: 3 }}
       >
         <Typography variant="h3">Runbooks</Typography>
-        <Button variant="contained" startIcon={<AddIcon />}>
-          New Runbook
-        </Button>
+        <Stack direction="row" spacing={1}>
+          {runbooks.length > 0 && (
+            <Button size="small" startIcon={<DownloadIcon />} onClick={handleExport}>
+              Export
+            </Button>
+          )}
+          <Button size="small" startIcon={<UploadIcon />} onClick={handleImportClick}>
+            Import
+          </Button>
+          <Button variant="contained" startIcon={<AddIcon />} onClick={() => setFormOpen(true)}>
+            New Runbook
+          </Button>
+        </Stack>
       </Stack>
 
       <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
@@ -38,6 +72,16 @@ export default function App() {
       </Typography>
 
       <RunbookList />
+
+      <RunbookFormDialog open={formOpen} onClose={() => setFormOpen(false)} />
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json"
+        hidden
+        onChange={handleFileChange}
+      />
     </Box>
   );
 }

--- a/ui/src/components/RunbookCard.tsx
+++ b/ui/src/components/RunbookCard.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import {
+  Card,
+  CardContent,
+  Typography,
+  IconButton,
+  Chip,
+  Stack,
+  Box,
+} from "@mui/material";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import type { Runbook } from "../types";
+import { RunbookFormDialog } from "./RunbookFormDialog";
+import { RunbookDeleteDialog } from "./RunbookDeleteDialog";
+import { RunbookExecutionDialog } from "./RunbookExecutionDialog";
+
+interface RunbookCardProps {
+  runbook: Runbook;
+}
+
+export function RunbookCard({ runbook }: RunbookCardProps) {
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [execOpen, setExecOpen] = useState(false);
+
+  return (
+    <>
+      <Card variant="outlined">
+        <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 } }}>
+          <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.5 }}>
+            <Typography variant="subtitle1" component="div" sx={{ flexShrink: 0, fontWeight: 600, lineHeight: 1.3 }}>
+              {runbook.name}
+            </Typography>
+            {runbook.tags.map((tag) => (
+              <Chip key={tag} label={tag} size="small" />
+            ))}
+            <Box sx={{ flex: 1 }} />
+            <IconButton size="small" color="primary" title="Run" onClick={() => setExecOpen(true)}>
+              <PlayArrowIcon fontSize="small" />
+            </IconButton>
+            <IconButton size="small" title="Edit" onClick={() => setEditOpen(true)}>
+              <EditIcon fontSize="small" />
+            </IconButton>
+            <IconButton size="small" title="Delete" color="error" onClick={() => setDeleteOpen(true)}>
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Stack>
+          {runbook.description && (
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+              {runbook.description}
+            </Typography>
+          )}
+          <Box
+            component="pre"
+            sx={{
+              bgcolor: "action.hover",
+              p: 1,
+              borderRadius: 1,
+              fontSize: "0.8rem",
+              lineHeight: 1.4,
+              maxHeight: "calc(0.8rem * 1.4 * 3 + 16px)",
+              overflowY: "auto",
+              overflowX: "auto",
+              m: 0,
+            }}
+          >
+            {runbook.commands.join("\n")}
+          </Box>
+        </CardContent>
+      </Card>
+
+      <RunbookFormDialog open={editOpen} onClose={() => setEditOpen(false)} runbook={runbook} />
+      <RunbookDeleteDialog open={deleteOpen} onClose={() => setDeleteOpen(false)} runbook={runbook} />
+      <RunbookExecutionDialog open={execOpen} onClose={() => setExecOpen(false)} runbook={runbook} />
+    </>
+  );
+}

--- a/ui/src/components/RunbookDeleteDialog.tsx
+++ b/ui/src/components/RunbookDeleteDialog.tsx
@@ -1,0 +1,45 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+} from "@mui/material";
+import type { Runbook } from "../types";
+import { useRunbooks } from "../context/RunbookContext";
+import { useDockerDesktopClient } from "../App";
+
+interface RunbookDeleteDialogProps {
+  open: boolean;
+  onClose: () => void;
+  runbook: Runbook;
+}
+
+export function RunbookDeleteDialog({ open, onClose, runbook }: RunbookDeleteDialogProps) {
+  const { deleteRunbook } = useRunbooks();
+  const ddClient = useDockerDesktopClient();
+
+  const handleDelete = () => {
+    deleteRunbook(runbook.id);
+    ddClient.desktopUI.toast.success(`Deleted "${runbook.name}"`);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Delete Runbook</DialogTitle>
+      <DialogContent>
+        <Typography>
+          Are you sure you want to delete &quot;{runbook.name}&quot;? This cannot be undone.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button color="error" variant="contained" onClick={handleDelete}>
+          Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/ui/src/components/RunbookExecutionDialog.tsx
+++ b/ui/src/components/RunbookExecutionDialog.tsx
@@ -1,0 +1,168 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Stack,
+  Box,
+  CircularProgress,
+} from "@mui/material";
+import type { Runbook, CommandResult, ExecutionStatus } from "../types";
+import { useDockerDesktopClient } from "../App";
+
+interface RunbookExecutionDialogProps {
+  open: boolean;
+  onClose: () => void;
+  runbook: Runbook;
+}
+
+function parseCommand(raw: string): string[] {
+  const tokens = raw.split(/\s+/).filter(Boolean);
+  if (tokens[0]?.toLowerCase() === "docker") {
+    tokens.shift();
+  }
+  return tokens;
+}
+
+export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecutionDialogProps) {
+  const ddClient = useDockerDesktopClient();
+  const [status, setStatus] = useState<ExecutionStatus>("idle");
+  const [results, setResults] = useState<CommandResult[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(-1);
+  const abortRef = useRef(false);
+
+  const execute = useCallback(async () => {
+    abortRef.current = false;
+    setStatus("running");
+    setResults([]);
+    setCurrentIndex(0);
+
+    const collected: CommandResult[] = [];
+
+    for (let i = 0; i < runbook.commands.length; i++) {
+      if (abortRef.current) break;
+      setCurrentIndex(i);
+
+      const raw = runbook.commands[i].trim();
+      const tokens = parseCommand(raw);
+      const start = performance.now();
+
+      try {
+        const result = await ddClient.docker.cli.exec(tokens[0], tokens.slice(1));
+        const duration = Math.round(performance.now() - start);
+        collected.push({
+          command: raw,
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exitCode: 0,
+          duration,
+        });
+      } catch (err: unknown) {
+        const duration = Math.round(performance.now() - start);
+        const message = err instanceof Error ? err.message : String(err);
+        collected.push({
+          command: raw,
+          stdout: "",
+          stderr: message,
+          exitCode: 1,
+          duration,
+        });
+        setResults([...collected]);
+        setCurrentIndex(i);
+        setStatus("failed");
+        ddClient.desktopUI.toast.error(`Runbook failed: ${runbook.name}`);
+        return;
+      }
+
+      setResults([...collected]);
+    }
+
+    if (abortRef.current) {
+      setStatus("idle");
+    } else {
+      setStatus("completed");
+      ddClient.desktopUI.toast.success(`Runbook completed: ${runbook.name}`);
+    }
+    setCurrentIndex(-1);
+  }, [ddClient, runbook]);
+
+  useEffect(() => {
+    if (open) {
+      execute();
+    }
+    return () => {
+      abortRef.current = true;
+    };
+    // Run once when dialog opens
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const handleClose = () => {
+    abortRef.current = true;
+    setStatus("idle");
+    setResults([]);
+    setCurrentIndex(-1);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
+      <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        Running: {runbook.name}
+        {status === "running" && <CircularProgress size={20} />}
+      </DialogTitle>
+      <DialogContent>
+        <Stack spacing={2}>
+          {runbook.commands.map((cmd, i) => (
+            <Box key={i}>
+              <Typography variant="subtitle2" sx={{ fontFamily: "monospace" }}>
+                $ {cmd}
+                {i === currentIndex && status === "running" && " (running...)"}
+              </Typography>
+              {results[i] && (
+                <Box
+                  component="pre"
+                  sx={{
+                    bgcolor: results[i].exitCode === 0 ? "action.hover" : "error.main",
+                    color: results[i].exitCode === 0 ? "text.primary" : "error.contrastText",
+                    p: 1.5,
+                    borderRadius: 1,
+                    fontSize: "0.8rem",
+                    overflow: "auto",
+                    maxHeight: 200,
+                    m: 0,
+                    mt: 0.5,
+                  }}
+                >
+                  {results[i].stdout || results[i].stderr || "(no output)"}
+                </Box>
+              )}
+            </Box>
+          ))}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        {status === "completed" && (
+          <Typography variant="body2" color="success.main" sx={{ mr: "auto", ml: 2 }}>
+            All commands completed successfully
+          </Typography>
+        )}
+        {status === "failed" && (
+          <Typography variant="body2" color="error" sx={{ mr: "auto", ml: 2 }}>
+            Execution stopped due to error
+          </Typography>
+        )}
+        {status === "running" ? (
+          <Button onClick={() => { abortRef.current = true; }} color="error">
+            Abort
+          </Button>
+        ) : (
+          <Button onClick={handleClose}>Close</Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/ui/src/components/RunbookFormDialog.tsx
+++ b/ui/src/components/RunbookFormDialog.tsx
@@ -1,0 +1,124 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Stack,
+} from "@mui/material";
+import type { Runbook } from "../types";
+import { useRunbooks } from "../context/RunbookContext";
+
+interface RunbookFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  runbook?: Runbook;
+}
+
+export function RunbookFormDialog({ open, onClose, runbook }: RunbookFormDialogProps) {
+  const { addRunbook, updateRunbook } = useRunbooks();
+  const isEdit = Boolean(runbook);
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [commands, setCommands] = useState("");
+  const [tags, setTags] = useState("");
+
+  useEffect(() => {
+    if (open && runbook) {
+      setName(runbook.name);
+      setDescription(runbook.description);
+      setCommands(runbook.commands.join("\n"));
+      setTags(runbook.tags.join(", "));
+    } else if (open) {
+      setName("");
+      setDescription("");
+      setCommands("");
+      setTags("");
+    }
+  }, [open, runbook]);
+
+  const handleSave = () => {
+    const commandList = commands
+      .split("\n")
+      .map((c) => c.trim())
+      .filter(Boolean);
+    const tagList = tags
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    if (!name.trim() || commandList.length === 0) return;
+
+    if (isEdit && runbook) {
+      updateRunbook(runbook.id, {
+        name: name.trim(),
+        description: description.trim(),
+        commands: commandList,
+        tags: tagList,
+      });
+    } else {
+      addRunbook({
+        name: name.trim(),
+        description: description.trim(),
+        commands: commandList,
+        tags: tagList,
+      });
+    }
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{isEdit ? "Edit Runbook" : "New Runbook"}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            fullWidth
+            autoFocus
+          />
+          <TextField
+            label="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            fullWidth
+          />
+          <TextField
+            label="Commands (one per line)"
+            value={commands}
+            onChange={(e) => setCommands(e.target.value)}
+            multiline
+            minRows={3}
+            required
+            fullWidth
+            inputProps={{ style: { fontFamily: "monospace" } }}
+            helperText="Each line is a Docker command, e.g. 'container prune -f'"
+          />
+          <TextField
+            label="Tags (comma-separated)"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            fullWidth
+            placeholder="cleanup, dev, production"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={!name.trim() || !commands.trim()}
+        >
+          {isEdit ? "Save" : "Create"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/ui/src/components/RunbookList.tsx
+++ b/ui/src/components/RunbookList.tsx
@@ -1,104 +1,34 @@
-import {
-  Box,
-  Card,
-  CardContent,
-  CardActions,
-  Typography,
-  IconButton,
-  Chip,
-  Stack,
-} from "@mui/material";
-import PlayArrowIcon from "@mui/icons-material/PlayArrow";
-import EditIcon from "@mui/icons-material/Edit";
-import DeleteIcon from "@mui/icons-material/Delete";
-
-// Placeholder type — will be refined as the data model solidifies.
-// See ADR-003 for storage architecture decisions.
-export interface Runbook {
-  id: string;
-  name: string;
-  description: string;
-  commands: string[];
-  tags: string[];
-  createdAt: string;
-  updatedAt: string;
-}
-
-// Sample data to demonstrate the UI concept.
-// Replace with real storage once ADR-003 storage backend is implemented.
-const SAMPLE_RUNBOOKS: Runbook[] = [
-  {
-    id: "1",
-    name: "Dev Cleanup",
-    description: "Remove stopped containers and dangling images",
-    commands: [
-      "docker container prune -f",
-      "docker image prune -f",
-    ],
-    tags: ["cleanup", "dev"],
-    createdAt: "2025-02-16T00:00:00Z",
-    updatedAt: "2025-02-16T00:00:00Z",
-  },
-  {
-    id: "2",
-    name: "Full Reset",
-    description: "Nuclear option — remove everything and start fresh",
-    commands: [
-      "docker stop $(docker ps -aq)",
-      "docker system prune -af --volumes",
-    ],
-    tags: ["cleanup", "dangerous"],
-    createdAt: "2025-02-16T00:00:00Z",
-    updatedAt: "2025-02-16T00:00:00Z",
-  },
-];
+import { Box, Typography } from "@mui/material";
+import { useRunbooks } from "../context/RunbookContext";
+import { RunbookCard } from "./RunbookCard";
 
 export function RunbookList() {
+  const { runbooks } = useRunbooks();
+
+  if (runbooks.length === 0) {
+    return (
+      <Box sx={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <Typography color="text.secondary">
+          No runbooks yet. Click "New Runbook" to create one.
+        </Typography>
+      </Box>
+    );
+  }
+
   return (
-    <Box sx={{ flex: 1, overflow: "auto" }}>
-      <Stack spacing={2}>
-        {SAMPLE_RUNBOOKS.map((runbook) => (
-          <Card key={runbook.id} variant="outlined">
-            <CardContent>
-              <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
-                <Typography variant="h6" component="div">
-                  {runbook.name}
-                </Typography>
-                {runbook.tags.map((tag) => (
-                  <Chip key={tag} label={tag} size="small" />
-                ))}
-              </Stack>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                {runbook.description}
-              </Typography>
-              <Box
-                component="pre"
-                sx={{
-                  bgcolor: "action.hover",
-                  p: 1.5,
-                  borderRadius: 1,
-                  fontSize: "0.85rem",
-                  overflow: "auto",
-                  m: 0,
-                }}
-              >
-                {runbook.commands.join("\n")}
-              </Box>
-            </CardContent>
-            <CardActions>
-              <IconButton color="primary" title="Run">
-                <PlayArrowIcon />
-              </IconButton>
-              <IconButton title="Edit">
-                <EditIcon />
-              </IconButton>
-              <IconButton title="Delete" color="error">
-                <DeleteIcon />
-              </IconButton>
-            </CardActions>
-          </Card>
-        ))}
-      </Stack>
+    <Box
+      sx={{
+        flex: 1,
+        overflow: "auto",
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(340px, 1fr))",
+        gap: 1.5,
+        alignContent: "start",
+      }}
+    >
+      {runbooks.map((runbook) => (
+        <RunbookCard key={runbook.id} runbook={runbook} />
+      ))}
     </Box>
   );
 }

--- a/ui/src/context/RunbookContext.tsx
+++ b/ui/src/context/RunbookContext.tsx
@@ -1,0 +1,73 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+import type { Runbook } from "../types";
+import { loadRunbooks, saveRunbooks } from "../storage";
+
+interface RunbookContextValue {
+  runbooks: Runbook[];
+  addRunbook: (data: Omit<Runbook, "id" | "createdAt" | "updatedAt">) => void;
+  updateRunbook: (id: string, updates: Partial<Omit<Runbook, "id" | "createdAt">>) => void;
+  deleteRunbook: (id: string) => void;
+  replaceAll: (runbooks: Runbook[]) => void;
+}
+
+const RunbookContext = createContext<RunbookContextValue | null>(null);
+
+export function RunbookProvider({ children }: { children: ReactNode }) {
+  const [runbooks, setRunbooks] = useState<Runbook[]>(() => loadRunbooks());
+
+  const addRunbook = useCallback(
+    (data: Omit<Runbook, "id" | "createdAt" | "updatedAt">) => {
+      const now = new Date().toISOString();
+      const newRunbook: Runbook = {
+        ...data,
+        id: crypto.randomUUID(),
+        createdAt: now,
+        updatedAt: now,
+      };
+      setRunbooks((prev) => {
+        const next = [...prev, newRunbook];
+        saveRunbooks(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const updateRunbook = useCallback(
+    (id: string, updates: Partial<Omit<Runbook, "id" | "createdAt">>) => {
+      setRunbooks((prev) => {
+        const next = prev.map((r) =>
+          r.id === id ? { ...r, ...updates, updatedAt: new Date().toISOString() } : r,
+        );
+        saveRunbooks(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const deleteRunbook = useCallback((id: string) => {
+    setRunbooks((prev) => {
+      const next = prev.filter((r) => r.id !== id);
+      saveRunbooks(next);
+      return next;
+    });
+  }, []);
+
+  const replaceAll = useCallback((imported: Runbook[]) => {
+    saveRunbooks(imported);
+    setRunbooks(imported);
+  }, []);
+
+  return (
+    <RunbookContext.Provider value={{ runbooks, addRunbook, updateRunbook, deleteRunbook, replaceAll }}>
+      {children}
+    </RunbookContext.Provider>
+  );
+}
+
+export function useRunbooks(): RunbookContextValue {
+  const ctx = useContext(RunbookContext);
+  if (!ctx) throw new Error("useRunbooks must be used within RunbookProvider");
+  return ctx;
+}

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -2,17 +2,20 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { DockerMuiThemeProvider } from "@docker/docker-mui-theme";
 import CssBaseline from "@mui/material/CssBaseline";
+import { RunbookProvider } from "./context/RunbookContext";
 import App from "./App";
 
 const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement
+  document.getElementById("root") as HTMLElement,
 );
 
 root.render(
   <React.StrictMode>
     <DockerMuiThemeProvider>
       <CssBaseline />
-      <App />
+      <RunbookProvider>
+        <App />
+      </RunbookProvider>
     </DockerMuiThemeProvider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/ui/src/storage.ts
+++ b/ui/src/storage.ts
@@ -1,0 +1,110 @@
+import type { Runbook } from "./types";
+
+const STORAGE_KEY = "runbooks-data";
+
+const DEFAULT_RUNBOOKS: Runbook[] = [
+  {
+    id: "example-1",
+    name: "Running Containers",
+    description: "Show all running containers with key details",
+    commands: [
+      'ps --format "table {{.Names}}\\t{{.Image}}\\t{{.Status}}\\t{{.Ports}}"',
+    ],
+    tags: ["info"],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "example-2",
+    name: "Disk Usage",
+    description: "Check how much disk space Docker is using",
+    commands: ["system df"],
+    tags: ["info"],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "example-3",
+    name: "Quick Cleanup",
+    description: "Remove stopped containers and dangling images",
+    commands: ["container prune -f", "image prune -f"],
+    tags: ["cleanup"],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "example-4",
+    name: "Full Reset",
+    description: "Remove all unused containers, networks, images, and volumes",
+    commands: ["system prune -af --volumes"],
+    tags: ["cleanup", "caution"],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "example-5",
+    name: "Network Overview",
+    description: "List all Docker networks",
+    commands: ["network ls"],
+    tags: ["info"],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "example-6",
+    name: "Volume Inventory",
+    description: "List all volumes and check for dangling ones",
+    commands: [
+      "volume ls",
+      'volume ls --filter "dangling=true"',
+    ],
+    tags: ["info"],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+];
+
+export function loadRunbooks(): Runbook[] {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return DEFAULT_RUNBOOKS;
+  try {
+    return JSON.parse(raw) as Runbook[];
+  } catch {
+    return DEFAULT_RUNBOOKS;
+  }
+}
+
+export function saveRunbooks(runbooks: Runbook[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(runbooks));
+}
+
+export function exportRunbooks(runbooks: Runbook[]): void {
+  const json = JSON.stringify(runbooks, null, 2);
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `runbooks-${new Date().toISOString().slice(0, 10)}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function importRunbooks(file: File): Promise<Runbook[]> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const data = JSON.parse(e.target?.result as string);
+        if (!Array.isArray(data)) {
+          reject(new Error("Invalid format: expected an array"));
+          return;
+        }
+        resolve(data as Runbook[]);
+      } catch {
+        reject(new Error("Invalid JSON file"));
+      }
+    };
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsText(file);
+  });
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -1,0 +1,19 @@
+export interface Runbook {
+  id: string;
+  name: string;
+  description: string;
+  commands: string[];
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CommandResult {
+  command: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  duration: number;
+}
+
+export type ExecutionStatus = "idle" | "running" | "completed" | "failed";


### PR DESCRIPTION
## Summary

- Full runbook CRUD: create, edit, and delete via Material UI dialogs
- Sequential Docker command execution with live output, stop-on-first-failure, and abort support
- Export runbooks to JSON file / import from JSON file (replaces all)
- localStorage persistence with 6 pre-seeded example runbooks for beginners
- React Context state management (no external dependencies)
- Responsive multi-column CSS Grid layout with compact card design
- ADR-005 documenting localStorage as MVP storage backend
- Deduplicated `.dockerignore`

## New files (7)

| File | Purpose |
|------|---------|
| `ui/src/types.ts` | Shared types: `Runbook`, `CommandResult`, `ExecutionStatus` |
| `ui/src/storage.ts` | localStorage load/save + default runbooks + JSON export/import |
| `ui/src/context/RunbookContext.tsx` | React Context provider with CRUD operations |
| `ui/src/components/RunbookCard.tsx` | Individual card with inline action buttons |
| `ui/src/components/RunbookFormDialog.tsx` | Shared create/edit dialog |
| `ui/src/components/RunbookDeleteDialog.tsx` | Delete confirmation dialog |
| `ui/src/components/RunbookExecutionDialog.tsx` | Command execution with live output |

## Test plan

- [ ] Create a runbook via "New Runbook" dialog
- [ ] Edit an existing runbook, verify changes persist
- [ ] Delete a runbook with confirmation
- [ ] Execute a safe command (e.g., `ps`), verify output displays
- [ ] Export runbooks, delete all, import, verify restoration
- [ ] Reload extension tab, verify localStorage persistence
- [ ] Verify multi-column layout at different window widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)