### PR TITLE
feat: Search, sort, nested grouping, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Open the extension
+        2. Click '...'
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: docker-version
+    attributes:
+      label: Docker Desktop version
+      placeholder: "e.g., 4.60.1"
+    validations:
+      required: false
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this solve, or why would it be useful?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should this work? Include any design ideas.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,11 @@
+name: Feedback
+description: General feedback, questions, or suggestions
+labels: ["feedback"]
+body:
+  - type: textarea
+    id: feedback
+    attributes:
+      label: Your feedback
+      description: Share your thoughts, questions, or suggestions.
+    validations:
+      required: true

--- a/ui/src/components/RunbookList.tsx
+++ b/ui/src/components/RunbookList.tsx
@@ -1,34 +1,317 @@
-import { Box, Typography } from "@mui/material";
+import { useState, useMemo } from "react";
+import {
+  Box,
+  Typography,
+  TextField,
+  Select,
+  MenuItem,
+  InputAdornment,
+  Stack,
+  Chip,
+  IconButton,
+  Tooltip,
+  Button,
+  Collapse,
+} from "@mui/material";
+import type { SelectChangeEvent } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+import SortIcon from "@mui/icons-material/Sort";
+import FolderIcon from "@mui/icons-material/Folder";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import { useRunbooks } from "../context/RunbookContext";
+import { loadPreference, savePreference } from "../storage";
+import type { SortOption, Runbook } from "../types";
 import { RunbookCard } from "./RunbookCard";
+
+const gridSx = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fill, minmax(340px, 1fr))",
+  gap: 1.5,
+  alignContent: "start",
+};
+
+interface SubGroup {
+  tag: string;
+  runbooks: Runbook[];
+}
+
+interface PrimaryGroup {
+  tag: string;
+  direct: Runbook[];
+  subgroups: SubGroup[];
+}
 
 export function RunbookList() {
   const { runbooks } = useRunbooks();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortBy, setSortBy] = useState<SortOption>(
+    () => loadPreference<SortOption>("sortBy", "name-asc"),
+  );
+  const [groupByTag, setGroupByTag] = useState<boolean>(
+    () => loadPreference<boolean>("groupByTag", false),
+  );
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  const filtered = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return runbooks;
+    return runbooks.filter(
+      (r) =>
+        r.name.toLowerCase().includes(q) ||
+        r.description.toLowerCase().includes(q) ||
+        r.tags.some((t) => t.toLowerCase().includes(q)) ||
+        r.commands.some((c) => c.toLowerCase().includes(q)),
+    );
+  }, [runbooks, searchQuery]);
+
+  const sorted = useMemo(() => {
+    const arr = [...filtered];
+    switch (sortBy) {
+      case "name-asc":
+        return arr.sort((a, b) => a.name.localeCompare(b.name));
+      case "name-desc":
+        return arr.sort((a, b) => b.name.localeCompare(a.name));
+      case "created-desc":
+        return arr.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+      case "created-asc":
+        return arr.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+      case "modified-desc":
+        return arr.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+      case "modified-asc":
+        return arr.sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
+      default:
+        return arr;
+    }
+  }, [filtered, sortBy]);
+
+  const groups = useMemo((): PrimaryGroup[] | null => {
+    if (!groupByTag) return null;
+
+    const primaryMap = new Map<string, { direct: Runbook[]; subs: Map<string, Runbook[]> }>();
+    const ungrouped: Runbook[] = [];
+
+    for (const r of sorted) {
+      if (r.tags.length === 0) {
+        ungrouped.push(r);
+      } else {
+        const primary = r.tags[0];
+        if (!primaryMap.has(primary)) {
+          primaryMap.set(primary, { direct: [], subs: new Map() });
+        }
+        const group = primaryMap.get(primary)!;
+        if (r.tags.length >= 2) {
+          const sub = r.tags[1];
+          if (!group.subs.has(sub)) group.subs.set(sub, []);
+          group.subs.get(sub)!.push(r);
+        } else {
+          group.direct.push(r);
+        }
+      }
+    }
+
+    const result: PrimaryGroup[] = [...primaryMap.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([tag, { direct, subs }]) => ({
+        tag,
+        direct,
+        subgroups: [...subs.entries()]
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([subTag, subRunbooks]) => ({ tag: subTag, runbooks: subRunbooks })),
+      }));
+
+    if (ungrouped.length > 0) {
+      result.push({ tag: "Ungrouped", direct: ungrouped, subgroups: [] });
+    }
+    return result;
+  }, [sorted, groupByTag]);
+
+  const toggleCollapse = (key: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const handleSortChange = (e: SelectChangeEvent) => {
+    const value = e.target.value as SortOption;
+    setSortBy(value);
+    savePreference("sortBy", value);
+  };
+
+  const handleGroupToggle = () => {
+    setGroupByTag((prev) => {
+      const next = !prev;
+      savePreference("groupByTag", next);
+      return next;
+    });
+  };
+
+  const totalInGroup = (g: PrimaryGroup) =>
+    g.direct.length + g.subgroups.reduce((sum, s) => sum + s.runbooks.length, 0);
 
   if (runbooks.length === 0) {
     return (
-      <Box sx={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <Box
+        sx={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
         <Typography color="text.secondary">
-          No runbooks yet. Click "New Runbook" to create one.
+          No runbooks yet. Click &quot;New Runbook&quot; to create one.
         </Typography>
       </Box>
     );
   }
 
   return (
-    <Box
-      sx={{
-        flex: 1,
-        overflow: "auto",
-        display: "grid",
-        gridTemplateColumns: "repeat(auto-fill, minmax(340px, 1fr))",
-        gap: 1.5,
-        alignContent: "start",
-      }}
-    >
-      {runbooks.map((runbook) => (
-        <RunbookCard key={runbook.id} runbook={runbook} />
-      ))}
+    <Box sx={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+      {/* Toolbar */}
+      <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 1.5 }}>
+        <Tooltip title="Filter by name, description, tags, or commands" placement="bottom">
+          <TextField
+            size="small"
+            placeholder="Search runbooks..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" />
+                </InputAdornment>
+              ),
+            }}
+            sx={{ flex: 1 }}
+          />
+        </Tooltip>
+        <Select
+          size="small"
+          value={sortBy}
+          onChange={handleSortChange}
+          startAdornment={<SortIcon fontSize="small" sx={{ mr: 0.5 }} />}
+          sx={{ minWidth: 170 }}
+        >
+          <MenuItem value="name-asc">Name A-Z</MenuItem>
+          <MenuItem value="name-desc">Name Z-A</MenuItem>
+          <MenuItem value="created-desc">Newest</MenuItem>
+          <MenuItem value="created-asc">Oldest</MenuItem>
+          <MenuItem value="modified-desc">Recently Modified</MenuItem>
+          <MenuItem value="modified-asc">Least Recently Modified</MenuItem>
+        </Select>
+        <Tooltip title="Group by tags. First tag = group, second tag = sub-group." placement="bottom">
+          <Button
+            size="small"
+            variant={groupByTag ? "contained" : "outlined"}
+            startIcon={<FolderIcon />}
+            onClick={handleGroupToggle}
+            sx={{ whiteSpace: "nowrap" }}
+          >
+            Group
+          </Button>
+        </Tooltip>
+      </Stack>
+
+      {/* Content */}
+      {sorted.length === 0 ? (
+        <Box
+          sx={{
+            flex: 1,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Typography color="text.secondary">
+            No runbooks match your search.
+          </Typography>
+        </Box>
+      ) : groups ? (
+        <Box sx={{ flex: 1, overflow: "auto" }}>
+          <Stack spacing={2}>
+            {groups.map((group) => (
+              <Box key={group.tag}>
+                {/* Primary group header */}
+                <Stack
+                  direction="row"
+                  alignItems="center"
+                  spacing={0.5}
+                  onClick={() => toggleCollapse(group.tag)}
+                  sx={{ cursor: "pointer", mb: 0.5, userSelect: "none" }}
+                >
+                  <IconButton size="small">
+                    {collapsed.has(group.tag) ? (
+                      <ExpandMoreIcon fontSize="small" />
+                    ) : (
+                      <ExpandLessIcon fontSize="small" />
+                    )}
+                  </IconButton>
+                  <Chip label={group.tag} size="small" />
+                  <Typography variant="body2" color="text.secondary">
+                    ({totalInGroup(group)})
+                  </Typography>
+                </Stack>
+                <Collapse in={!collapsed.has(group.tag)}>
+                  <Box sx={{ pl: 2 }}>
+                    {/* Direct runbooks (single-tag, no sub-group) */}
+                    {group.direct.length > 0 && (
+                      <Box sx={{ ...gridSx, mb: group.subgroups.length > 0 ? 1.5 : 0 }}>
+                        {group.direct.map((runbook) => (
+                          <RunbookCard key={runbook.id} runbook={runbook} />
+                        ))}
+                      </Box>
+                    )}
+                    {/* Sub-groups (second tag) */}
+                    {group.subgroups.map((sub) => {
+                      const subKey = `${group.tag}/${sub.tag}`;
+                      return (
+                        <Box key={subKey} sx={{ mb: 1 }}>
+                          <Stack
+                            direction="row"
+                            alignItems="center"
+                            spacing={0.5}
+                            onClick={() => toggleCollapse(subKey)}
+                            sx={{ cursor: "pointer", mb: 0.5, userSelect: "none" }}
+                          >
+                            <IconButton size="small">
+                              {collapsed.has(subKey) ? (
+                                <ExpandMoreIcon sx={{ fontSize: "1rem" }} />
+                              ) : (
+                                <ExpandLessIcon sx={{ fontSize: "1rem" }} />
+                              )}
+                            </IconButton>
+                            <Chip label={sub.tag} size="small" variant="outlined" />
+                            <Typography variant="body2" color="text.secondary">
+                              ({sub.runbooks.length})
+                            </Typography>
+                          </Stack>
+                          <Collapse in={!collapsed.has(subKey)}>
+                            <Box sx={{ ...gridSx, pl: 2 }}>
+                              {sub.runbooks.map((runbook) => (
+                                <RunbookCard key={runbook.id} runbook={runbook} />
+                              ))}
+                            </Box>
+                          </Collapse>
+                        </Box>
+                      );
+                    })}
+                  </Box>
+                </Collapse>
+              </Box>
+            ))}
+          </Stack>
+        </Box>
+      ) : (
+        <Box sx={{ flex: 1, overflow: "auto", ...gridSx }}>
+          {sorted.map((runbook) => (
+            <RunbookCard key={runbook.id} runbook={runbook} />
+          ))}
+        </Box>
+      )}
     </Box>
   );
 }

--- a/ui/src/storage.ts
+++ b/ui/src/storage.ts
@@ -1,6 +1,7 @@
 import type { Runbook } from "./types";
 
 const STORAGE_KEY = "runbooks-data";
+const PREFS_KEY = "runbooks-prefs";
 
 const DEFAULT_RUNBOOKS: Runbook[] = [
   {
@@ -87,6 +88,25 @@ export function exportRunbooks(runbooks: Runbook[]): void {
   a.download = `runbooks-${new Date().toISOString().slice(0, 10)}.json`;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+export function loadPreference<T>(key: string, fallback: T): T {
+  try {
+    const prefs = JSON.parse(localStorage.getItem(PREFS_KEY) ?? "{}");
+    return key in prefs ? prefs[key] : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function savePreference(key: string, value: unknown): void {
+  try {
+    const prefs = JSON.parse(localStorage.getItem(PREFS_KEY) ?? "{}");
+    prefs[key] = value;
+    localStorage.setItem(PREFS_KEY, JSON.stringify(prefs));
+  } catch {
+    // silently ignore
+  }
 }
 
 export function importRunbooks(file: File): Promise<Runbook[]> {

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -17,3 +17,5 @@ export interface CommandResult {
 }
 
 export type ExecutionStatus = "idle" | "running" | "completed" | "failed";
+
+export type SortOption = "name-asc" | "name-desc" | "created-desc" | "created-asc" | "modified-desc" | "modified-asc";


### PR DESCRIPTION
## Summary

- Real-time search bar filtering by name, description, tags, and commands
- Sort dropdown with 6 options (name, created, modified) -- persists to localStorage
- Two-level nested grouping by tags: first tag = primary group, second tag = sub-group
- Collapsible sections with animated expand/collapse and item counts
- Tooltips on search and group controls for discoverability
- GitHub issue templates: bug report, feature request, feedback
- Priority labels (high/medium/low) and category labels (ui/storage/execution)

Closes #3

## Test plan

- [ ] Type in search bar, verify real-time filtering across all fields
- [ ] Change sort, reload extension, verify preference persists
- [ ] Toggle Group on: verify first tag creates primary group, second tag creates sub-group
- [ ] Click group headers to collapse/expand
- [ ] Search while grouped: empty groups should disappear
- [ ] Hover search and Group button to see tooltips
- [ ] Visit repo Issues tab, verify 3 templates appear in "New issue" chooser

🤖 Generated with [Claude Code](https://claude.com/claude-code)