### PR TITLE
feat: Collapsible cards with expand/collapse all

### DIFF
--- a/ui/src/components/RunbookCard.tsx
+++ b/ui/src/components/RunbookCard.tsx
@@ -7,10 +7,13 @@ import {
   Chip,
   Stack,
   Box,
+  Collapse,
 } from "@mui/material";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import type { Runbook } from "../types";
 import { RunbookFormDialog } from "./RunbookFormDialog";
 import { RunbookDeleteDialog } from "./RunbookDeleteDialog";
@@ -18,9 +21,11 @@ import { RunbookExecutionDialog } from "./RunbookExecutionDialog";
 
 interface RunbookCardProps {
   runbook: Runbook;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
 }
 
-export function RunbookCard({ runbook }: RunbookCardProps) {
+export function RunbookCard({ runbook, collapsed = false, onToggleCollapse }: RunbookCardProps) {
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [execOpen, setExecOpen] = useState(false);
@@ -29,7 +34,16 @@ export function RunbookCard({ runbook }: RunbookCardProps) {
     <>
       <Card variant="outlined">
         <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 } }}>
-          <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.5 }}>
+          <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: collapsed ? 0 : 0.5 }}>
+            {onToggleCollapse && (
+              <IconButton size="small" onClick={onToggleCollapse} title={collapsed ? "Expand" : "Collapse"}>
+                {collapsed ? (
+                  <ExpandMoreIcon sx={{ fontSize: "1rem" }} />
+                ) : (
+                  <ExpandLessIcon sx={{ fontSize: "1rem" }} />
+                )}
+              </IconButton>
+            )}
             <Typography variant="subtitle1" component="div" sx={{ flexShrink: 0, fontWeight: 600, lineHeight: 1.3 }}>
               {runbook.name}
             </Typography>
@@ -47,27 +61,31 @@ export function RunbookCard({ runbook }: RunbookCardProps) {
               <DeleteIcon fontSize="small" />
             </IconButton>
           </Stack>
-          {runbook.description && (
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
-              {runbook.description}
-            </Typography>
-          )}
-          <Box
-            component="pre"
-            sx={{
-              bgcolor: "action.hover",
-              p: 1,
-              borderRadius: 1,
-              fontSize: "0.8rem",
-              lineHeight: 1.4,
-              maxHeight: "calc(0.8rem * 1.4 * 3 + 16px)",
-              overflowY: "auto",
-              overflowX: "auto",
-              m: 0,
-            }}
-          >
-            {runbook.commands.join("\n")}
-          </Box>
+          <Collapse in={!collapsed}>
+            <>
+              {runbook.description && (
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+                  {runbook.description}
+                </Typography>
+              )}
+              <Box
+                component="pre"
+                sx={{
+                  bgcolor: "action.hover",
+                  p: 1,
+                  borderRadius: 1,
+                  fontSize: "0.8rem",
+                  lineHeight: 1.4,
+                  maxHeight: "calc(0.8rem * 1.4 * 3 + 16px)",
+                  overflowY: "auto",
+                  overflowX: "auto",
+                  m: 0,
+                }}
+              >
+                {runbook.commands.join("\n")}
+              </Box>
+            </>
+          </Collapse>
         </CardContent>
       </Card>
 

--- a/ui/src/components/RunbookList.tsx
+++ b/ui/src/components/RunbookList.tsx
@@ -19,6 +19,8 @@ import SortIcon from "@mui/icons-material/Sort";
 import FolderIcon from "@mui/icons-material/Folder";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import UnfoldLessIcon from "@mui/icons-material/UnfoldLess";
+import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
 import { useRunbooks } from "../context/RunbookContext";
 import { loadPreference, savePreference } from "../storage";
 import type { SortOption, Runbook } from "../types";
@@ -52,6 +54,7 @@ export function RunbookList() {
     () => loadPreference<boolean>("groupByTag", false),
   );
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [collapsedCards, setCollapsedCards] = useState<Set<string>>(new Set());
 
   const filtered = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
@@ -149,6 +152,18 @@ export function RunbookList() {
     });
   };
 
+  const toggleCardCollapse = (id: string) => {
+    setCollapsedCards((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const expandAllCards = () => setCollapsedCards(new Set());
+  const collapseAllCards = () => setCollapsedCards(new Set(sorted.map((r) => r.id)));
+
   const totalInGroup = (g: PrimaryGroup) =>
     g.direct.length + g.subgroups.reduce((sum, s) => sum + s.runbooks.length, 0);
 
@@ -203,6 +218,16 @@ export function RunbookList() {
           <MenuItem value="modified-desc">Recently Modified</MenuItem>
           <MenuItem value="modified-asc">Least Recently Modified</MenuItem>
         </Select>
+        <Tooltip title="Expand all cards" placement="bottom">
+          <IconButton size="small" onClick={expandAllCards}>
+            <UnfoldMoreIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Collapse all cards" placement="bottom">
+          <IconButton size="small" onClick={collapseAllCards}>
+            <UnfoldLessIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
         <Tooltip title="Group by tags. First tag = group, second tag = sub-group." placement="bottom">
           <Button
             size="small"
@@ -261,7 +286,7 @@ export function RunbookList() {
                     {group.direct.length > 0 && (
                       <Box sx={{ ...gridSx, mb: group.subgroups.length > 0 ? 1.5 : 0 }}>
                         {group.direct.map((runbook) => (
-                          <RunbookCard key={runbook.id} runbook={runbook} />
+                          <RunbookCard key={runbook.id} runbook={runbook} collapsed={collapsedCards.has(runbook.id)} onToggleCollapse={() => toggleCardCollapse(runbook.id)} />
                         ))}
                       </Box>
                     )}
@@ -292,7 +317,7 @@ export function RunbookList() {
                           <Collapse in={!collapsed.has(subKey)}>
                             <Box sx={{ ...gridSx, pl: 2 }}>
                               {sub.runbooks.map((runbook) => (
-                                <RunbookCard key={runbook.id} runbook={runbook} />
+                                <RunbookCard key={runbook.id} runbook={runbook} collapsed={collapsedCards.has(runbook.id)} onToggleCollapse={() => toggleCardCollapse(runbook.id)} />
                               ))}
                             </Box>
                           </Collapse>
@@ -308,7 +333,7 @@ export function RunbookList() {
       ) : (
         <Box sx={{ flex: 1, overflow: "auto", ...gridSx }}>
           {sorted.map((runbook) => (
-            <RunbookCard key={runbook.id} runbook={runbook} />
+            <RunbookCard key={runbook.id} runbook={runbook} collapsed={collapsedCards.has(runbook.id)} onToggleCollapse={() => toggleCardCollapse(runbook.id)} />
           ))}
         </Box>
       )}


### PR DESCRIPTION
## Summary

- Each card has an expand/collapse arrow in the title row to toggle description and commands
- Expand All / Collapse All icon buttons in toolbar (between sort dropdown and group button)
- Collapsed cards show only the title row with tags and action buttons

Closes #8

## Test plan

- [ ] Click card arrow to collapse -- description and commands hide
- [ ] Click again to expand
- [ ] Click Collapse All -- all cards collapse to title-only
- [ ] Click Expand All -- all cards expand
- [ ] Collapse all, then expand individual cards selectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)