### PR TITLE
chore: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - run: npm ci
+      - run: npm run build


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` for automated build validation
- Triggers on push to `main` and all pull requests
- Runs `npm ci` + `npm run build` (TypeScript + Vite) using Node 22
- Node version matches Dockerfile (`node:22-alpine`)

Closes #15

## Test plan

- [ ] This PR itself triggers the workflow (proof it works)
- [ ] Workflow completes with green check

🤖 Generated with [Claude Code](https://claude.com/claude-code)