### PR TITLE
feat: rule-based command validation with syntax highlighting

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15,7 +15,8 @@
         "@mui/icons-material": "^5.15.0",
         "@mui/material": "^5.15.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-simple-code-editor": "^0.14.1"
       },
       "devDependencies": {
         "@types/react": "^18.2.0",
@@ -2027,6 +2028,15 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="
+    },
+    "node_modules/react-simple-code-editor": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.14.1.tgz",
+      "integrity": "sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,8 @@
     "@mui/icons-material": "^5.15.0",
     "@mui/material": "^5.15.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-simple-code-editor": "^0.14.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/ui/src/components/CommandEditor.tsx
+++ b/ui/src/components/CommandEditor.tsx
@@ -1,0 +1,128 @@
+import Editor from "react-simple-code-editor";
+import { Box, FormHelperText, useTheme } from "@mui/material";
+import { ALL_COMMANDS, MANAGEMENT_COMMANDS, DOCKER_COMMANDS } from "../docker-commands";
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Regex-based Docker CLI syntax highlighter */
+function highlightDocker(code: string): string {
+  return code
+    .split("\n")
+    .map((line) => {
+      const escaped = escapeHtml(line);
+
+      // Comment lines
+      if (/^\s*#/.test(line)) {
+        return `<span style="color:var(--docker-comment)">${escaped}</span>`;
+      }
+
+      const trimmed = line.trim();
+      if (!trimmed) return escaped;
+
+      // Tokenize: split on whitespace, highlight each token
+      let result = "";
+      let remaining = escaped;
+      const tokens = trimmed.split(/\s+/);
+      const firstToken = tokens[0].toLowerCase();
+
+      // Check if first token is a known command or management command
+      const isKnownCommand = ALL_COMMANDS.has(firstToken);
+      const isMgmtCommand = MANAGEMENT_COMMANDS.has(firstToken);
+
+      for (let i = 0; i < tokens.length; i++) {
+        const token = escapeHtml(tokens[i]);
+        const tokenIdx = remaining.indexOf(token);
+        if (tokenIdx > 0) {
+          result += remaining.slice(0, tokenIdx);
+        }
+        remaining = remaining.slice(tokenIdx + token.length);
+
+        if (i === 0 && isKnownCommand) {
+          // First token: known command (blue)
+          result += `<span style="color:var(--docker-command)">${token}</span>`;
+        } else if (i === 1 && isMgmtCommand) {
+          // Second token after management command: sub-command
+          const subs = DOCKER_COMMANDS[firstToken]?.subcommands;
+          const isValidSub = subs && tokens[1].toLowerCase() in subs;
+          if (isValidSub) {
+            result += `<span style="color:var(--docker-subcommand)">${token}</span>`;
+          } else {
+            result += `<span style="color:var(--docker-unknown);text-decoration:wavy underline var(--docker-unknown)">${token}</span>`;
+          }
+        } else if (i === 0 && !isKnownCommand && trimmed.length > 0) {
+          // Unknown first token
+          result += `<span style="color:var(--docker-unknown);text-decoration:wavy underline var(--docker-unknown)">${token}</span>`;
+        } else if (/^--?[a-zA-Z]/.test(tokens[i])) {
+          // Flags
+          result += `<span style="color:var(--docker-flag)">${token}</span>`;
+        } else if (/^["']/.test(tokens[i])) {
+          // Quoted strings
+          result += `<span style="color:var(--docker-string)">${token}</span>`;
+        } else {
+          result += token;
+        }
+      }
+      result += remaining;
+      return result;
+    })
+    .join("\n");
+}
+
+interface CommandEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function CommandEditor({ value, onChange }: CommandEditorProps) {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+
+  const cssVars = {
+    "--docker-command": isDark ? "#6cb6ff" : "#0550ae",
+    "--docker-subcommand": isDark ? "#7ee787" : "#116329",
+    "--docker-flag": isDark ? "#d2a8ff" : "#8250df",
+    "--docker-string": isDark ? "#a5d6ff" : "#0a3069",
+    "--docker-comment": isDark ? "#8b949e" : "#6e7781",
+    "--docker-unknown": isDark ? "#f85149" : "#cf222e",
+  } as React.CSSProperties;
+
+  return (
+    <Box sx={cssVars}>
+      <Box
+        sx={{
+          border: 1,
+          borderColor: "divider",
+          borderRadius: 1,
+          overflow: "auto",
+          maxHeight: 200,
+          "&:focus-within": {
+            borderColor: "primary.main",
+            borderWidth: 2,
+            m: "-1px",
+          },
+        }}
+      >
+        <Editor
+          value={value}
+          onValueChange={onChange}
+          highlight={highlightDocker}
+          padding={12}
+          style={{
+            fontFamily: '"Roboto Mono", "Consolas", monospace',
+            fontSize: 13,
+            lineHeight: 1.5,
+            minHeight: 80,
+            color: theme.palette.text.primary,
+            background: "transparent",
+          }}
+          textareaClassName="command-editor-textarea"
+        />
+      </Box>
+      <FormHelperText>
+        Each line is a Docker command, e.g. &apos;container prune -f&apos;
+      </FormHelperText>
+    </Box>
+  );
+}

--- a/ui/src/components/RunbookFormDialog.tsx
+++ b/ui/src/components/RunbookFormDialog.tsx
@@ -10,9 +10,17 @@ import {
   Autocomplete,
   Chip,
   Alert,
+  Typography,
 } from "@mui/material";
 import type { Runbook } from "../types";
 import { useRunbooks } from "../context/RunbookContext";
+import { CommandEditor } from "./CommandEditor";
+import {
+  DOCKER_COMMANDS,
+  ALL_COMMANDS,
+  MANAGEMENT_COMMANDS,
+  findClosest,
+} from "../docker-commands";
 
 const COMMON_TAGS = ["info", "cleanup", "dev", "production", "maintenance", "monitoring", "caution"];
 
@@ -21,15 +29,49 @@ function validateCommands(raw: string): string[] {
   const lines = raw.split("\n");
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i].trim();
-    if (!line) continue;
+    if (!line || line.startsWith("#")) continue;
+
+    // Phase 1: Basic pattern checks
     if (/^docker\s+/i.test(line)) {
       warnings.push(`Line ${i + 1}: Remove leading "docker" — the extension adds it automatically.`);
+      continue;
     }
     if (/[;&|]/.test(line)) {
       warnings.push(`Line ${i + 1}: Shell operators (;, &, |) may not work. Use separate lines instead.`);
     }
     if (/\$\{?\w/.test(line)) {
       warnings.push(`Line ${i + 1}: Variable substitution ($VAR) is not supported.`);
+    }
+
+    // Phase 2: Command tree validation
+    const tokens = line.split(/\s+/);
+    const cmd = tokens[0].toLowerCase();
+
+    if (!ALL_COMMANDS.has(cmd)) {
+      const suggestion = findClosest(cmd, ALL_COMMANDS);
+      if (suggestion) {
+        warnings.push(`Line ${i + 1}: Unknown command "${tokens[0]}". Did you mean "${suggestion}"?`);
+      } else {
+        warnings.push(`Line ${i + 1}: Unknown command "${tokens[0]}".`);
+      }
+      continue;
+    }
+
+    // Check sub-commands for management commands
+    if (MANAGEMENT_COMMANDS.has(cmd)) {
+      const subs = DOCKER_COMMANDS[cmd].subcommands;
+      if (subs && tokens.length > 1) {
+        const sub = tokens[1].toLowerCase();
+        // Skip if it looks like a flag (e.g., compose --file)
+        if (!sub.startsWith("-") && !(sub in subs)) {
+          const subSuggestion = findClosest(sub, Object.keys(subs));
+          if (subSuggestion) {
+            warnings.push(
+              `Line ${i + 1}: Unknown sub-command "${tokens[1]}" for "${cmd}". Did you mean "${subSuggestion}"?`,
+            );
+          }
+        }
+      }
     }
   }
   return warnings;
@@ -118,17 +160,12 @@ export function RunbookFormDialog({ open, onClose, runbook }: RunbookFormDialogP
             onChange={(e) => setDescription(e.target.value)}
             fullWidth
           />
-          <TextField
-            label="Commands (one per line)"
-            value={commands}
-            onChange={(e) => setCommands(e.target.value)}
-            multiline
-            minRows={3}
-            required
-            fullWidth
-            inputProps={{ style: { fontFamily: "monospace" } }}
-            helperText="Each line is a Docker command, e.g. 'container prune -f'"
-          />
+          <div>
+            <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+              Commands (one per line) *
+            </Typography>
+            <CommandEditor value={commands} onChange={setCommands} />
+          </div>
           {commandWarnings.length > 0 && (
             <Alert severity="warning" sx={{ py: 0, "& .MuiAlert-message": { fontSize: "0.8rem" } }}>
               {commandWarnings.map((w) => (

--- a/ui/src/docker-commands.ts
+++ b/ui/src/docker-commands.ts
@@ -1,0 +1,264 @@
+/**
+ * Static Docker CLI command tree for validation and syntax highlighting.
+ * Covers core engine commands + compose + buildx.
+ * Unknown top-level commands produce warnings (not errors) to handle new plugins.
+ */
+
+export interface DockerCommand {
+  description: string;
+  subcommands?: Record<string, string>;
+  aliasOf?: string;
+}
+
+/** Core management commands and their sub-commands */
+export const DOCKER_COMMANDS: Record<string, DockerCommand> = {
+  // ── Core Management Commands ──
+  container: {
+    description: "Manage containers",
+    subcommands: {
+      attach: "Attach to a running container",
+      commit: "Create image from container changes",
+      cp: "Copy files between container and host",
+      create: "Create a new container",
+      diff: "Inspect filesystem changes",
+      exec: "Execute a command in a container",
+      export: "Export container filesystem",
+      inspect: "Display container info",
+      kill: "Kill running containers",
+      logs: "Fetch container logs",
+      ls: "List containers",
+      pause: "Pause container processes",
+      port: "List port mappings",
+      prune: "Remove stopped containers",
+      rename: "Rename a container",
+      restart: "Restart containers",
+      rm: "Remove containers",
+      run: "Create and run a container",
+      start: "Start stopped containers",
+      stats: "Display resource usage",
+      stop: "Stop running containers",
+      top: "Display running processes",
+      unpause: "Unpause containers",
+      update: "Update container configuration",
+      wait: "Block until containers stop",
+    },
+  },
+  image: {
+    description: "Manage images",
+    subcommands: {
+      build: "Build from a Dockerfile",
+      history: "Show image history",
+      import: "Import from tarball",
+      inspect: "Display image info",
+      load: "Load from tar archive",
+      ls: "List images",
+      prune: "Remove unused images",
+      pull: "Download from registry",
+      push: "Upload to registry",
+      rm: "Remove images",
+      save: "Save to tar archive",
+      tag: "Tag an image",
+    },
+  },
+  network: {
+    description: "Manage networks",
+    subcommands: {
+      connect: "Connect container to network",
+      create: "Create a network",
+      disconnect: "Disconnect from network",
+      inspect: "Display network info",
+      ls: "List networks",
+      prune: "Remove unused networks",
+      rm: "Remove networks",
+    },
+  },
+  volume: {
+    description: "Manage volumes",
+    subcommands: {
+      create: "Create a volume",
+      inspect: "Display volume info",
+      ls: "List volumes",
+      prune: "Remove unused volumes",
+      rm: "Remove volumes",
+    },
+  },
+  system: {
+    description: "Manage Docker",
+    subcommands: {
+      df: "Show disk usage",
+      events: "Get real-time events",
+      info: "Display system info",
+      prune: "Remove unused data",
+    },
+  },
+  context: {
+    description: "Manage contexts",
+    subcommands: {
+      create: "Create a context",
+      inspect: "Display context info",
+      ls: "List contexts",
+      rm: "Remove contexts",
+      show: "Show current context",
+      update: "Update a context",
+      use: "Set current context",
+    },
+  },
+  builder: {
+    description: "Manage builds",
+    subcommands: {
+      build: "Build from a Dockerfile",
+      prune: "Remove build cache",
+    },
+  },
+  plugin: {
+    description: "Manage plugins",
+    subcommands: {
+      create: "Create a plugin",
+      disable: "Disable a plugin",
+      enable: "Enable a plugin",
+      inspect: "Display plugin info",
+      install: "Install a plugin",
+      ls: "List plugins",
+      push: "Push a plugin",
+      rm: "Remove a plugin",
+      set: "Change plugin settings",
+      upgrade: "Upgrade a plugin",
+    },
+  },
+
+  // ── Docker Desktop Plugin Commands ──
+  compose: {
+    description: "Docker Compose",
+    subcommands: {
+      build: "Build or rebuild services",
+      config: "Validate and view Compose file",
+      cp: "Copy files between service and host",
+      create: "Create service containers",
+      down: "Stop and remove containers",
+      events: "Receive real-time events",
+      exec: "Execute in a running container",
+      images: "List images used by services",
+      kill: "Kill service containers",
+      logs: "View service output",
+      ls: "List Compose projects",
+      pause: "Pause services",
+      port: "Print port binding for a port",
+      ps: "List containers",
+      pull: "Pull service images",
+      push: "Push service images",
+      restart: "Restart service containers",
+      rm: "Remove stopped containers",
+      run: "Run a one-off command",
+      start: "Start services",
+      stop: "Stop services",
+      top: "Display running processes",
+      unpause: "Unpause services",
+      up: "Create and start containers",
+      version: "Show Compose version",
+      watch: "Watch build context and rebuild",
+    },
+  },
+  buildx: {
+    description: "Docker Buildx",
+    subcommands: {
+      bake: "Build from a Bake file",
+      build: "Build from a Dockerfile",
+      create: "Create a builder instance",
+      du: "Disk usage",
+      inspect: "Inspect builder instance",
+      ls: "List builder instances",
+      prune: "Remove build cache",
+      rm: "Remove a builder instance",
+      stop: "Stop builder instance",
+      use: "Set current builder",
+      version: "Show Buildx version",
+    },
+  },
+
+  // ── Top-Level Shortcut Aliases ──
+  attach: { description: "Attach to a running container", aliasOf: "container attach" },
+  build: { description: "Build an image", aliasOf: "image build" },
+  commit: { description: "Create image from container", aliasOf: "container commit" },
+  cp: { description: "Copy files", aliasOf: "container cp" },
+  create: { description: "Create a container", aliasOf: "container create" },
+  diff: { description: "Inspect filesystem changes", aliasOf: "container diff" },
+  events: { description: "Get real-time events", aliasOf: "system events" },
+  exec: { description: "Execute in a container", aliasOf: "container exec" },
+  export: { description: "Export container filesystem", aliasOf: "container export" },
+  history: { description: "Show image history", aliasOf: "image history" },
+  images: { description: "List images", aliasOf: "image ls" },
+  import: { description: "Import from tarball", aliasOf: "image import" },
+  info: { description: "Display system info", aliasOf: "system info" },
+  inspect: { description: "Display object info" },
+  kill: { description: "Kill containers", aliasOf: "container kill" },
+  load: { description: "Load image from archive", aliasOf: "image load" },
+  login: { description: "Log in to a registry" },
+  logout: { description: "Log out from a registry" },
+  logs: { description: "Fetch container logs", aliasOf: "container logs" },
+  pause: { description: "Pause containers", aliasOf: "container pause" },
+  port: { description: "List port mappings", aliasOf: "container port" },
+  ps: { description: "List containers", aliasOf: "container ls" },
+  pull: { description: "Download image", aliasOf: "image pull" },
+  push: { description: "Upload image", aliasOf: "image push" },
+  rename: { description: "Rename a container", aliasOf: "container rename" },
+  restart: { description: "Restart containers", aliasOf: "container restart" },
+  rm: { description: "Remove containers", aliasOf: "container rm" },
+  rmi: { description: "Remove images", aliasOf: "image rm" },
+  run: { description: "Create and run a container", aliasOf: "container run" },
+  save: { description: "Save image to archive", aliasOf: "image save" },
+  search: { description: "Search Docker Hub" },
+  start: { description: "Start containers", aliasOf: "container start" },
+  stats: { description: "Display resource usage", aliasOf: "container stats" },
+  stop: { description: "Stop containers", aliasOf: "container stop" },
+  tag: { description: "Tag an image", aliasOf: "image tag" },
+  top: { description: "Display running processes", aliasOf: "container top" },
+  unpause: { description: "Unpause containers", aliasOf: "container unpause" },
+  update: { description: "Update container config", aliasOf: "container update" },
+  version: { description: "Show Docker version" },
+  wait: { description: "Block until containers stop", aliasOf: "container wait" },
+};
+
+/** All valid top-level command names (for highlighting and validation) */
+export const ALL_COMMANDS = new Set(Object.keys(DOCKER_COMMANDS));
+
+/** Management commands that have sub-commands */
+export const MANAGEMENT_COMMANDS = new Set(
+  Object.entries(DOCKER_COMMANDS)
+    .filter(([, cmd]) => cmd.subcommands)
+    .map(([name]) => name),
+);
+
+/**
+ * Simple Levenshtein distance for "did you mean?" suggestions.
+ * Only computes for short strings (command names are short).
+ */
+export function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0) as number[]);
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+    }
+  }
+  return dp[m][n];
+}
+
+/** Find the closest command name within a max distance of 2 */
+export function findClosest(input: string, candidates: Iterable<string>): string | null {
+  let best: string | null = null;
+  let bestDist = 3;
+  for (const candidate of candidates) {
+    const d = levenshtein(input, candidate);
+    if (d < bestDist) {
+      bestDist = d;
+      best = candidate;
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
## Summary

- Add static Docker CLI command tree (~125 entries) for typo detection with Levenshtein "did you mean?" suggestions
- Replace plain textarea with `react-simple-code-editor` (+6.6KB gzip, 0 deps) for Docker-specific syntax highlighting
- Color-coded commands, sub-commands, flags, strings, and comments with theme-aware dark/light mode
- Unknown commands and sub-commands highlighted with red wavy underline

## New Files

- `ui/src/docker-commands.ts` -- command tree, Levenshtein distance, closest-match finder
- `ui/src/components/CommandEditor.tsx` -- syntax-highlighted editor component

## Test plan

- [ ] Create a runbook with valid commands (e.g., `container ls`, `compose up -d`) -- should highlight correctly
- [ ] Type a misspelled command (e.g., `contaner ls`) -- should show "Did you mean container?" warning
- [ ] Type unknown sub-command (e.g., `container rn`) -- should suggest "run"
- [ ] Verify dark mode and light mode colors look correct
- [ ] Verify existing Phase 1 warnings still work (leading docker, shell operators, variable substitution)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)