### PR TITLE
feat: add first-class group categories

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash",
+      "Read",
+      "Edit",
+      "Write",
+      "WebFetch",
+      "WebSearch",
+      "Glob",
+      "Grep",
+      "Task",
+      "Skill",
+      "mcp__*",
+      "mcp__MCP_DOCKER__read_file",
+      "mcp__memory__search_nodes",
+      "mcp__memory__create_entities",
+      "mcp__memory__create_relations",
+      "mcp__MCP_DOCKER__fetch"
+    ]
+  },
+  "enableAllProjectMcpServers": true
+}

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,9 @@
+# Voluntary financial support for SubNetree development.
+# These links appear on the GitHub "Sponsor" button.
+#
+# SubNetree is free for personal/home use forever.
+# Financial support is voluntary and does not unlock additional features.
+
+github: HerbHall
+ko_fi: herbhall
+buy_me_a_coffee: herbhall

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,9 +4,12 @@ import { Box, Typography, Stack, Button } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import DownloadIcon from "@mui/icons-material/Download";
 import UploadIcon from "@mui/icons-material/Upload";
+import SettingsIcon from "@mui/icons-material/Settings";
 import { RunbookList } from "./components/RunbookList";
 import { RunbookFormDialog } from "./components/RunbookFormDialog";
+import { CategoryManagementDialog } from "./components/CategoryManagementDialog";
 import { useRunbooks } from "./context/RunbookContext";
+import { useCategories } from "./context/CategoryContext";
 import { exportRunbooks, importRunbooks } from "./storage";
 
 const ddClient = createDockerDesktopClient();
@@ -17,11 +20,13 @@ export function useDockerDesktopClient() {
 
 export default function App() {
   const { runbooks, replaceAll } = useRunbooks();
+  const { categories, replaceAllCategories } = useCategories();
   const [formOpen, setFormOpen] = useState(false);
+  const [categoryDialogOpen, setCategoryDialogOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleExport = () => {
-    exportRunbooks(runbooks);
+    exportRunbooks(runbooks, categories);
     ddClient.desktopUI.toast.success("Runbooks exported");
   };
 
@@ -33,9 +38,12 @@ export default function App() {
     const file = e.target.files?.[0];
     if (!file) return;
     try {
-      const imported = await importRunbooks(file);
-      replaceAll(imported);
-      ddClient.desktopUI.toast.success(`Imported ${imported.length} runbooks`);
+      const result = await importRunbooks(file);
+      replaceAll(result.runbooks);
+      if (result.categories) {
+        replaceAllCategories(result.categories);
+      }
+      ddClient.desktopUI.toast.success(`Imported ${result.runbooks.length} runbooks`);
     } catch (err) {
       ddClient.desktopUI.toast.error(err instanceof Error ? err.message : "Import failed");
     }
@@ -52,6 +60,9 @@ export default function App() {
       >
         <Typography variant="h3">Runbooks</Typography>
         <Stack direction="row" spacing={1}>
+          <Button size="small" startIcon={<SettingsIcon />} onClick={() => setCategoryDialogOpen(true)}>
+            Categories
+          </Button>
           {runbooks.length > 0 && (
             <Button size="small" startIcon={<DownloadIcon />} onClick={handleExport}>
               Export
@@ -74,6 +85,7 @@ export default function App() {
       <RunbookList />
 
       <RunbookFormDialog open={formOpen} onClose={() => setFormOpen(false)} />
+      <CategoryManagementDialog open={categoryDialogOpen} onClose={() => setCategoryDialogOpen(false)} />
 
       <input
         ref={fileInputRef}

--- a/ui/src/category-defaults.ts
+++ b/ui/src/category-defaults.ts
@@ -1,0 +1,69 @@
+import type { Category } from "./types";
+
+export const PRESET_COLORS = [
+  "#1976d2", // blue
+  "#2e7d32", // green
+  "#ed6c02", // orange
+  "#d32f2f", // red
+  "#7b1fa2", // purple
+  "#0288d1", // light blue
+  "#c2185b", // pink
+  "#455a64", // blue-grey
+];
+
+export const PRESET_ICONS = [
+  "rocket",
+  "wrench",
+  "shield",
+  "terminal",
+  "database",
+  "globe",
+  "alert",
+  "package",
+  "refresh",
+  "trash",
+  "eye",
+  "heart",
+];
+
+export const ICON_LABELS: Record<string, string> = {
+  rocket: "\u{1F680}",
+  wrench: "\u{1F527}",
+  shield: "\u{1F6E1}\uFE0F",
+  terminal: "\u{1F4BB}",
+  database: "\u{1F5C4}\uFE0F",
+  globe: "\u{1F310}",
+  alert: "\u26A0\uFE0F",
+  package: "\u{1F4E6}",
+  refresh: "\u{1F504}",
+  trash: "\u{1F5D1}\uFE0F",
+  eye: "\u{1F441}\uFE0F",
+  heart: "\u2764\uFE0F",
+};
+
+export const DEFAULT_CATEGORIES: Category[] = [
+  {
+    id: "cat-operations",
+    name: "Operations",
+    color: "#1976d2",
+    icon: "terminal",
+    parentId: null,
+    order: 0,
+  },
+  {
+    id: "cat-development",
+    name: "Development",
+    color: "#2e7d32",
+    icon: "rocket",
+    parentId: null,
+    order: 1,
+  },
+  {
+    id: "cat-maintenance",
+    name: "Maintenance",
+    color: "#ed6c02",
+    icon: "wrench",
+    parentId: null,
+    order: 2,
+  },
+];

--- a/ui/src/components/CategoryBadge.tsx
+++ b/ui/src/components/CategoryBadge.tsx
@@ -1,0 +1,35 @@
+import { Chip, Box } from "@mui/material";
+import type { Category } from "../types";
+import { ICON_LABELS } from "../category-defaults";
+
+interface CategoryBadgeProps {
+  category: Category;
+  size?: "small" | "medium";
+}
+
+export function CategoryBadge({ category, size = "small" }: CategoryBadgeProps) {
+  const emoji = ICON_LABELS[category.icon] ?? "";
+
+  return (
+    <Chip
+      size={size}
+      label={
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          <Box
+            sx={{
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              bgcolor: category.color,
+              flexShrink: 0,
+            }}
+          />
+          {emoji && <span>{emoji}</span>}
+          {category.name}
+        </Box>
+      }
+      variant="outlined"
+      sx={{ borderColor: category.color, color: "text.primary" }}
+    />
+  );
+}

--- a/ui/src/components/CategoryManagementDialog.tsx
+++ b/ui/src/components/CategoryManagementDialog.tsx
@@ -1,0 +1,231 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Stack,
+  Box,
+  Typography,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Divider,
+} from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import AddIcon from "@mui/icons-material/Add";
+import { useCategories } from "../context/CategoryContext";
+import { PRESET_COLORS, PRESET_ICONS, ICON_LABELS } from "../category-defaults";
+import type { Category } from "../types";
+
+interface CategoryManagementDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function CategoryManagementDialog({ open, onClose }: CategoryManagementDialogProps) {
+  const { categories, addCategory, updateCategory, deleteCategory, reorderCategories } = useCategories();
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  const [formName, setFormName] = useState("");
+  const [formColor, setFormColor] = useState(PRESET_COLORS[0]);
+  const [formIcon, setFormIcon] = useState(PRESET_ICONS[0]);
+
+  const sorted = [...categories].sort((a, b) => a.order - b.order);
+
+  const resetForm = () => {
+    setFormName("");
+    setFormColor(PRESET_COLORS[0]);
+    setFormIcon(PRESET_ICONS[0]);
+    setEditingId(null);
+    setShowForm(false);
+  };
+
+  const startEdit = (cat: Category) => {
+    setFormName(cat.name);
+    setFormColor(cat.color);
+    setFormIcon(cat.icon);
+    setEditingId(cat.id);
+    setShowForm(true);
+  };
+
+  const startAdd = () => {
+    resetForm();
+    setShowForm(true);
+  };
+
+  const handleSave = () => {
+    if (!formName.trim()) return;
+
+    if (editingId) {
+      updateCategory(editingId, { name: formName.trim(), color: formColor, icon: formIcon });
+    } else {
+      addCategory({ name: formName.trim(), color: formColor, icon: formIcon, parentId: null });
+    }
+    resetForm();
+  };
+
+  const handleDelete = (id: string) => {
+    deleteCategory(id);
+    if (editingId === id) resetForm();
+  };
+
+  const moveUp = (index: number) => {
+    if (index === 0) return;
+    const ids = sorted.map((c) => c.id);
+    [ids[index - 1], ids[index]] = [ids[index], ids[index - 1]];
+    reorderCategories(ids);
+  };
+
+  const moveDown = (index: number) => {
+    if (index >= sorted.length - 1) return;
+    const ids = sorted.map((c) => c.id);
+    [ids[index], ids[index + 1]] = [ids[index + 1], ids[index]];
+    reorderCategories(ids);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Manage Categories</DialogTitle>
+      <DialogContent>
+        <List dense>
+          {sorted.map((cat, i) => (
+            <ListItem
+              key={cat.id}
+              secondaryAction={
+                <Stack direction="row" spacing={0.5}>
+                  <IconButton size="small" onClick={() => moveUp(i)} disabled={i === 0}>
+                    <ArrowUpwardIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" onClick={() => moveDown(i)} disabled={i === sorted.length - 1}>
+                    <ArrowDownwardIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" onClick={() => startEdit(cat)}>
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" color="error" onClick={() => handleDelete(cat.id)}>
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </Stack>
+              }
+            >
+              <Box
+                sx={{
+                  width: 12,
+                  height: 12,
+                  borderRadius: "50%",
+                  bgcolor: cat.color,
+                  mr: 1,
+                  flexShrink: 0,
+                }}
+              />
+              <ListItemText
+                primary={
+                  <span>
+                    {ICON_LABELS[cat.icon] ?? ""} {cat.name}
+                  </span>
+                }
+              />
+            </ListItem>
+          ))}
+        </List>
+
+        {sorted.length === 0 && (
+          <Typography variant="body2" color="text.secondary" sx={{ py: 2, textAlign: "center" }}>
+            No categories yet. Add one below.
+          </Typography>
+        )}
+
+        <Divider sx={{ my: 1 }} />
+
+        {showForm ? (
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Typography variant="subtitle2">
+              {editingId ? "Edit Category" : "New Category"}
+            </Typography>
+            <TextField
+              label="Name"
+              value={formName}
+              onChange={(e) => setFormName(e.target.value)}
+              size="small"
+              fullWidth
+              autoFocus
+            />
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                Color
+              </Typography>
+              <Stack direction="row" spacing={0.5} sx={{ mt: 0.5, flexWrap: "wrap" }}>
+                {PRESET_COLORS.map((color) => (
+                  <Box
+                    key={color}
+                    onClick={() => setFormColor(color)}
+                    sx={{
+                      width: 28,
+                      height: 28,
+                      borderRadius: "50%",
+                      bgcolor: color,
+                      cursor: "pointer",
+                      border: formColor === color ? "3px solid" : "2px solid transparent",
+                      borderColor: formColor === color ? "text.primary" : "transparent",
+                    }}
+                  />
+                ))}
+              </Stack>
+            </Box>
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                Icon
+              </Typography>
+              <Stack direction="row" spacing={0.5} sx={{ mt: 0.5, flexWrap: "wrap" }}>
+                {PRESET_ICONS.map((icon) => (
+                  <Box
+                    key={icon}
+                    onClick={() => setFormIcon(icon)}
+                    sx={{
+                      width: 32,
+                      height: 32,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      borderRadius: 1,
+                      cursor: "pointer",
+                      fontSize: "1.2rem",
+                      border: formIcon === icon ? "2px solid" : "1px solid",
+                      borderColor: formIcon === icon ? "primary.main" : "divider",
+                      bgcolor: formIcon === icon ? "action.selected" : "transparent",
+                    }}
+                  >
+                    {ICON_LABELS[icon]}
+                  </Box>
+                ))}
+              </Stack>
+            </Box>
+            <Stack direction="row" spacing={1}>
+              <Button size="small" onClick={resetForm}>
+                Cancel
+              </Button>
+              <Button size="small" variant="contained" onClick={handleSave} disabled={!formName.trim()}>
+                {editingId ? "Update" : "Add"}
+              </Button>
+            </Stack>
+          </Stack>
+        ) : (
+          <Button size="small" startIcon={<AddIcon />} onClick={startAdd} sx={{ mt: 1 }}>
+            Add Category
+          </Button>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Done</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/ui/src/components/RunbookCard.tsx
+++ b/ui/src/components/RunbookCard.tsx
@@ -14,19 +14,21 @@ import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
-import type { Runbook } from "../types";
+import type { Runbook, Category } from "../types";
 import { RunbookFormDialog } from "./RunbookFormDialog";
 import { RunbookDeleteDialog } from "./RunbookDeleteDialog";
 import { RunbookExecutionDialog } from "./RunbookExecutionDialog";
+import { CategoryBadge } from "./CategoryBadge";
 
 interface RunbookCardProps {
   runbook: Runbook;
+  category?: Category;
   collapsed?: boolean;
   onToggleCollapse?: () => void;
   compact?: boolean;
 }
 
-export function RunbookCard({ runbook, collapsed = false, onToggleCollapse, compact = false }: RunbookCardProps) {
+export function RunbookCard({ runbook, category, collapsed = false, onToggleCollapse, compact = false }: RunbookCardProps) {
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [execOpen, setExecOpen] = useState(false);
@@ -48,6 +50,7 @@ export function RunbookCard({ runbook, collapsed = false, onToggleCollapse, comp
             <Typography variant={compact ? "body1" : "subtitle1"} component="div" sx={{ flexShrink: 0, fontWeight: 600, lineHeight: 1.3 }}>
               {runbook.name}
             </Typography>
+            {category && <CategoryBadge category={category} />}
             {runbook.tags.map((tag) => (
               <Chip key={tag} label={tag} size="small" />
             ))}

--- a/ui/src/components/RunbookFormDialog.tsx
+++ b/ui/src/components/RunbookFormDialog.tsx
@@ -11,9 +11,16 @@ import {
   Chip,
   Alert,
   Typography,
+  Select,
+  MenuItem,
+  Box,
+  FormControl,
+  InputLabel,
 } from "@mui/material";
 import type { Runbook } from "../types";
 import { useRunbooks } from "../context/RunbookContext";
+import { useCategories } from "../context/CategoryContext";
+import { ICON_LABELS } from "../category-defaults";
 import { CommandEditor } from "./CommandEditor";
 import {
   DOCKER_COMMANDS,
@@ -85,12 +92,14 @@ interface RunbookFormDialogProps {
 
 export function RunbookFormDialog({ open, onClose, runbook }: RunbookFormDialogProps) {
   const { runbooks, addRunbook, updateRunbook } = useRunbooks();
+  const { categories } = useCategories();
   const isEdit = Boolean(runbook);
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [commands, setCommands] = useState("");
   const [tagList, setTagList] = useState<string[]>([]);
+  const [categoryId, setCategoryId] = useState("");
 
   const commandWarnings = useMemo(() => validateCommands(commands), [commands]);
 
@@ -110,11 +119,13 @@ export function RunbookFormDialog({ open, onClose, runbook }: RunbookFormDialogP
       setDescription(runbook.description);
       setCommands(runbook.commands.join("\n"));
       setTagList([...runbook.tags]);
+      setCategoryId(runbook.categoryId ?? "");
     } else if (open) {
       setName("");
       setDescription("");
       setCommands("");
       setTagList([]);
+      setCategoryId("");
     }
   }, [open, runbook]);
 
@@ -131,6 +142,7 @@ export function RunbookFormDialog({ open, onClose, runbook }: RunbookFormDialogP
       description: description.trim(),
       commands: commandList,
       tags: tagList,
+      categoryId: categoryId || undefined,
     };
 
     if (isEdit && runbook) {
@@ -160,6 +172,28 @@ export function RunbookFormDialog({ open, onClose, runbook }: RunbookFormDialogP
             onChange={(e) => setDescription(e.target.value)}
             fullWidth
           />
+          {categories.length > 0 && (
+            <FormControl fullWidth size="small">
+              <InputLabel>Category</InputLabel>
+              <Select
+                value={categoryId}
+                onChange={(e) => setCategoryId(e.target.value)}
+                label="Category"
+              >
+                <MenuItem value="">
+                  <em>None</em>
+                </MenuItem>
+                {[...categories].sort((a, b) => a.order - b.order).map((cat) => (
+                  <MenuItem key={cat.id} value={cat.id}>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                      <Box sx={{ width: 10, height: 10, borderRadius: "50%", bgcolor: cat.color }} />
+                      {ICON_LABELS[cat.icon] ?? ""} {cat.name}
+                    </Box>
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
           <div>
             <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
               Commands (one per line) *

--- a/ui/src/components/RunbookList.tsx
+++ b/ui/src/components/RunbookList.tsx
@@ -10,7 +10,6 @@ import {
   Chip,
   IconButton,
   Tooltip,
-  Button,
   Collapse,
 } from "@mui/material";
 import type { SelectChangeEvent } from "@mui/material";
@@ -25,9 +24,11 @@ import GridViewIcon from "@mui/icons-material/GridView";
 import ViewListIcon from "@mui/icons-material/ViewList";
 import DensitySmallIcon from "@mui/icons-material/DensitySmall";
 import { useRunbooks } from "../context/RunbookContext";
+import { useCategories } from "../context/CategoryContext";
 import { loadPreference, savePreference } from "../storage";
-import type { SortOption, LayoutMode, Runbook } from "../types";
+import type { SortOption, LayoutMode, GroupMode, Runbook, Category } from "../types";
 import { RunbookCard } from "./RunbookCard";
+import { CategoryBadge } from "./CategoryBadge";
 
 const getLayoutSx = (mode: LayoutMode, compact: boolean) => {
   const gap = compact ? 1 : 1.5;
@@ -49,18 +50,22 @@ interface SubGroup {
 
 interface PrimaryGroup {
   tag: string;
+  color?: string;
+  icon?: string;
+  category?: Category;
   direct: Runbook[];
   subgroups: SubGroup[];
 }
 
 export function RunbookList() {
   const { runbooks } = useRunbooks();
+  const { categories } = useCategories();
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState<SortOption>(
     () => loadPreference<SortOption>("sortBy", "name-asc"),
   );
-  const [groupByTag, setGroupByTag] = useState<boolean>(
-    () => loadPreference<boolean>("groupByTag", false),
+  const [groupMode, setGroupMode] = useState<GroupMode>(
+    () => loadPreference<GroupMode>("groupMode", "none"),
   );
   const [layoutMode, setLayoutMode] = useState<LayoutMode>(
     () => loadPreference<LayoutMode>("layoutMode", "grid"),
@@ -70,6 +75,11 @@ export function RunbookList() {
   );
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [collapsedCards, setCollapsedCards] = useState<Set<string>>(new Set());
+
+  const categoryMap = useMemo(
+    () => new Map(categories.map((c) => [c.id, c])),
+    [categories],
+  );
 
   const layoutSx = useMemo(() => getLayoutSx(layoutMode, compact), [layoutMode, compact]);
 
@@ -81,9 +91,10 @@ export function RunbookList() {
         r.name.toLowerCase().includes(q) ||
         r.description.toLowerCase().includes(q) ||
         r.tags.some((t) => t.toLowerCase().includes(q)) ||
-        r.commands.some((c) => c.toLowerCase().includes(q)),
+        r.commands.some((c) => c.toLowerCase().includes(q)) ||
+        (r.categoryId && categoryMap.get(r.categoryId)?.name.toLowerCase().includes(q)),
     );
-  }, [runbooks, searchQuery]);
+  }, [runbooks, searchQuery, categoryMap]);
 
   const sorted = useMemo(() => {
     const arr = [...filtered];
@@ -106,8 +117,40 @@ export function RunbookList() {
   }, [filtered, sortBy]);
 
   const groups = useMemo((): PrimaryGroup[] | null => {
-    if (!groupByTag) return null;
+    if (groupMode === "none") return null;
 
+    if (groupMode === "category") {
+      const catGroups = new Map<string, Runbook[]>();
+      const ungrouped: Runbook[] = [];
+
+      for (const r of sorted) {
+        if (r.categoryId && categoryMap.has(r.categoryId)) {
+          if (!catGroups.has(r.categoryId)) catGroups.set(r.categoryId, []);
+          catGroups.get(r.categoryId)!.push(r);
+        } else {
+          ungrouped.push(r);
+        }
+      }
+
+      const sortedCats = [...categories].sort((a, b) => a.order - b.order);
+      const result: PrimaryGroup[] = sortedCats
+        .filter((cat) => catGroups.has(cat.id))
+        .map((cat) => ({
+          tag: cat.name,
+          color: cat.color,
+          icon: cat.icon,
+          category: cat,
+          direct: catGroups.get(cat.id) ?? [],
+          subgroups: [],
+        }));
+
+      if (ungrouped.length > 0) {
+        result.push({ tag: "Uncategorized", direct: ungrouped, subgroups: [] });
+      }
+      return result;
+    }
+
+    // groupMode === "tag"
     const primaryMap = new Map<string, { direct: Runbook[]; subs: Map<string, Runbook[]> }>();
     const ungrouped: Runbook[] = [];
 
@@ -144,7 +187,7 @@ export function RunbookList() {
       result.push({ tag: "Ungrouped", direct: ungrouped, subgroups: [] });
     }
     return result;
-  }, [sorted, groupByTag]);
+  }, [sorted, groupMode, categories, categoryMap]);
 
   const toggleCollapse = (key: string) => {
     setCollapsed((prev) => {
@@ -161,10 +204,14 @@ export function RunbookList() {
     savePreference("sortBy", value);
   };
 
-  const handleGroupToggle = () => {
-    setGroupByTag((prev) => {
-      const next = !prev;
-      savePreference("groupByTag", next);
+  const cycleGroupMode = () => {
+    setGroupMode((prev) => {
+      const modes: GroupMode[] = categories.length > 0
+        ? ["none", "tag", "category"]
+        : ["none", "tag"];
+      const idx = modes.indexOf(prev);
+      const next = modes[(idx + 1) % modes.length];
+      savePreference("groupMode", next);
       return next;
     });
   };
@@ -199,6 +246,19 @@ export function RunbookList() {
 
   const totalInGroup = (g: PrimaryGroup) =>
     g.direct.length + g.subgroups.reduce((sum, s) => sum + s.runbooks.length, 0);
+
+  const groupLabel = groupMode === "none" ? "Group" : groupMode === "tag" ? "By Tag" : "By Category";
+
+  const renderCard = (runbook: Runbook) => (
+    <RunbookCard
+      key={runbook.id}
+      runbook={runbook}
+      category={runbook.categoryId ? categoryMap.get(runbook.categoryId) : undefined}
+      collapsed={collapsedCards.has(runbook.id)}
+      onToggleCollapse={() => toggleCardCollapse(runbook.id)}
+      compact={compact}
+    />
+  );
 
   if (runbooks.length === 0) {
     return (
@@ -271,16 +331,16 @@ export function RunbookList() {
             <UnfoldLessIcon fontSize="small" />
           </IconButton>
         </Tooltip>
-        <Tooltip title="Group by tags. First tag = group, second tag = sub-group." placement="bottom">
-          <Button
+        <Tooltip title="Cycle grouping: None / By Tag / By Category" placement="bottom">
+          <Chip
+            icon={<FolderIcon />}
+            label={groupLabel}
             size="small"
-            variant={groupByTag ? "contained" : "outlined"}
-            startIcon={<FolderIcon />}
-            onClick={handleGroupToggle}
-            sx={{ whiteSpace: "nowrap" }}
-          >
-            Group
-          </Button>
+            color={groupMode !== "none" ? "primary" : "default"}
+            variant={groupMode !== "none" ? "filled" : "outlined"}
+            onClick={cycleGroupMode}
+            sx={{ cursor: "pointer" }}
+          />
         </Tooltip>
       </Stack>
 
@@ -303,7 +363,7 @@ export function RunbookList() {
           <Stack spacing={2}>
             {groups.map((group) => (
               <Box key={group.tag}>
-                {/* Primary group header */}
+                {/* Group header */}
                 <Stack
                   direction="row"
                   alignItems="center"
@@ -318,22 +378,22 @@ export function RunbookList() {
                       <ExpandLessIcon fontSize="small" />
                     )}
                   </IconButton>
-                  <Chip label={group.tag} size="small" />
+                  {group.category ? (
+                    <CategoryBadge category={group.category} />
+                  ) : (
+                    <Chip label={group.tag} size="small" />
+                  )}
                   <Typography variant="body2" color="text.secondary">
                     ({totalInGroup(group)})
                   </Typography>
                 </Stack>
                 <Collapse in={!collapsed.has(group.tag)}>
                   <Box sx={{ pl: 2 }}>
-                    {/* Direct runbooks (single-tag, no sub-group) */}
                     {group.direct.length > 0 && (
                       <Box sx={{ ...layoutSx, mb: group.subgroups.length > 0 ? 1.5 : 0 }}>
-                        {group.direct.map((runbook) => (
-                          <RunbookCard key={runbook.id} runbook={runbook} collapsed={collapsedCards.has(runbook.id)} onToggleCollapse={() => toggleCardCollapse(runbook.id)} compact={compact} />
-                        ))}
+                        {group.direct.map(renderCard)}
                       </Box>
                     )}
-                    {/* Sub-groups (second tag) */}
                     {group.subgroups.map((sub) => {
                       const subKey = `${group.tag}/${sub.tag}`;
                       return (
@@ -359,9 +419,7 @@ export function RunbookList() {
                           </Stack>
                           <Collapse in={!collapsed.has(subKey)}>
                             <Box sx={{ ...layoutSx, pl: 2 }}>
-                              {sub.runbooks.map((runbook) => (
-                                <RunbookCard key={runbook.id} runbook={runbook} collapsed={collapsedCards.has(runbook.id)} onToggleCollapse={() => toggleCardCollapse(runbook.id)} compact={compact} />
-                              ))}
+                              {sub.runbooks.map(renderCard)}
                             </Box>
                           </Collapse>
                         </Box>
@@ -375,9 +433,7 @@ export function RunbookList() {
         </Box>
       ) : (
         <Box sx={{ flex: 1, overflow: "auto", ...layoutSx }}>
-          {sorted.map((runbook) => (
-            <RunbookCard key={runbook.id} runbook={runbook} collapsed={collapsedCards.has(runbook.id)} onToggleCollapse={() => toggleCardCollapse(runbook.id)} compact={compact} />
-          ))}
+          {sorted.map(renderCard)}
         </Box>
       )}
     </Box>

--- a/ui/src/context/CategoryContext.tsx
+++ b/ui/src/context/CategoryContext.tsx
@@ -1,0 +1,86 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+import type { Category } from "../types";
+import { loadCategories, saveCategories } from "../storage";
+
+interface CategoryContextValue {
+  categories: Category[];
+  addCategory: (data: Omit<Category, "id" | "order">) => void;
+  updateCategory: (id: string, updates: Partial<Omit<Category, "id">>) => void;
+  deleteCategory: (id: string) => void;
+  reorderCategories: (ids: string[]) => void;
+  replaceAllCategories: (categories: Category[]) => void;
+}
+
+const CategoryContext = createContext<CategoryContextValue | null>(null);
+
+export function CategoryProvider({ children }: { children: ReactNode }) {
+  const [categories, setCategories] = useState<Category[]>(() => loadCategories());
+
+  const addCategory = useCallback(
+    (data: Omit<Category, "id" | "order">) => {
+      setCategories((prev) => {
+        const newCat: Category = {
+          ...data,
+          id: `cat-${crypto.randomUUID().slice(0, 8)}`,
+          order: prev.length,
+        };
+        const next = [...prev, newCat];
+        saveCategories(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const updateCategory = useCallback(
+    (id: string, updates: Partial<Omit<Category, "id">>) => {
+      setCategories((prev) => {
+        const next = prev.map((c) => (c.id === id ? { ...c, ...updates } : c));
+        saveCategories(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const deleteCategory = useCallback((id: string) => {
+    setCategories((prev) => {
+      const next = prev
+        .filter((c) => c.id !== id)
+        .map((c, i) => ({ ...c, order: i }));
+      saveCategories(next);
+      return next;
+    });
+  }, []);
+
+  const reorderCategories = useCallback((ids: string[]) => {
+    setCategories((prev) => {
+      const map = new Map(prev.map((c) => [c.id, c]));
+      const next = ids
+        .map((id) => map.get(id))
+        .filter((c): c is Category => c !== undefined)
+        .map((c, i) => ({ ...c, order: i }));
+      saveCategories(next);
+      return next;
+    });
+  }, []);
+
+  const replaceAllCategories = useCallback((imported: Category[]) => {
+    saveCategories(imported);
+    setCategories(imported);
+  }, []);
+
+  return (
+    <CategoryContext.Provider
+      value={{ categories, addCategory, updateCategory, deleteCategory, reorderCategories, replaceAllCategories }}
+    >
+      {children}
+    </CategoryContext.Provider>
+  );
+}
+
+export function useCategories(): CategoryContextValue {
+  const ctx = useContext(CategoryContext);
+  if (!ctx) throw new Error("useCategories must be used within CategoryProvider");
+  return ctx;
+}

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { DockerMuiThemeProvider } from "@docker/docker-mui-theme";
 import CssBaseline from "@mui/material/CssBaseline";
 import { RunbookProvider } from "./context/RunbookContext";
+import { CategoryProvider } from "./context/CategoryContext";
 import App from "./App";
 
 const root = ReactDOM.createRoot(
@@ -14,7 +15,9 @@ root.render(
     <DockerMuiThemeProvider>
       <CssBaseline />
       <RunbookProvider>
-        <App />
+        <CategoryProvider>
+          <App />
+        </CategoryProvider>
       </RunbookProvider>
     </DockerMuiThemeProvider>
   </React.StrictMode>,

--- a/ui/src/storage.ts
+++ b/ui/src/storage.ts
@@ -1,6 +1,8 @@
-import type { Runbook } from "./types";
+import type { Runbook, Category } from "./types";
+import { DEFAULT_CATEGORIES } from "./category-defaults";
 
 const STORAGE_KEY = "runbooks-data";
+const CATEGORIES_KEY = "runbooks-categories";
 const PREFS_KEY = "runbooks-prefs";
 
 const DEFAULT_RUNBOOKS: Runbook[] = [
@@ -79,8 +81,23 @@ export function saveRunbooks(runbooks: Runbook[]): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(runbooks));
 }
 
-export function exportRunbooks(runbooks: Runbook[]): void {
-  const json = JSON.stringify(runbooks, null, 2);
+export function loadCategories(): Category[] {
+  const raw = localStorage.getItem(CATEGORIES_KEY);
+  if (!raw) return DEFAULT_CATEGORIES;
+  try {
+    return JSON.parse(raw) as Category[];
+  } catch {
+    return DEFAULT_CATEGORIES;
+  }
+}
+
+export function saveCategories(categories: Category[]): void {
+  localStorage.setItem(CATEGORIES_KEY, JSON.stringify(categories));
+}
+
+export function exportRunbooks(runbooks: Runbook[], categories?: Category[]): void {
+  const payload = { runbooks, categories: categories ?? [] };
+  const json = JSON.stringify(payload, null, 2);
   const blob = new Blob([json], { type: "application/json" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
@@ -109,17 +126,28 @@ export function savePreference(key: string, value: unknown): void {
   }
 }
 
-export function importRunbooks(file: File): Promise<Runbook[]> {
+export interface ImportResult {
+  runbooks: Runbook[];
+  categories?: Category[];
+}
+
+export function importRunbooks(file: File): Promise<ImportResult> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = (e) => {
       try {
         const data = JSON.parse(e.target?.result as string);
-        if (!Array.isArray(data)) {
-          reject(new Error("Invalid format: expected an array"));
-          return;
+        // Support old format (plain array) and new format ({ runbooks, categories })
+        if (Array.isArray(data)) {
+          resolve({ runbooks: data as Runbook[] });
+        } else if (data && Array.isArray(data.runbooks)) {
+          resolve({
+            runbooks: data.runbooks as Runbook[],
+            categories: Array.isArray(data.categories) ? data.categories as Category[] : undefined,
+          });
+        } else {
+          reject(new Error("Invalid format: expected runbooks array or { runbooks, categories }"));
         }
-        resolve(data as Runbook[]);
       } catch {
         reject(new Error("Invalid JSON file"));
       }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -4,6 +4,7 @@ export interface Runbook {
   description: string;
   commands: string[];
   tags: string[];
+  categoryId?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -21,3 +22,14 @@ export type ExecutionStatus = "idle" | "running" | "completed" | "failed";
 export type SortOption = "name-asc" | "name-desc" | "created-desc" | "created-asc" | "modified-desc" | "modified-asc";
 
 export type LayoutMode = "grid" | "list";
+
+export interface Category {
+  id: string;
+  name: string;
+  color: string;
+  icon: string;
+  parentId: string | null;
+  order: number;
+}
+
+export type GroupMode = "none" | "tag" | "category";


### PR DESCRIPTION
## Summary

- Adds a category system for organizing runbooks with color coding, emoji icons, and display ordering
- Categories can be created, edited, reordered, and deleted via a management dialog
- Runbooks can be assigned to a category in the create/edit form
- Grouping now cycles through none / by tag / by category
- Backwards-compatible import supports both old array format and new `{runbooks, categories}` object
- Search includes category name matching

### New files

- `ui/src/types.ts` - `Category` interface, `categoryId` on Runbook, `GroupMode` type
- `ui/src/category-defaults.ts` - preset colors, icons, emoji labels, default categories
- `ui/src/context/CategoryContext.tsx` - CRUD context with localStorage persistence
- `ui/src/components/CategoryBadge.tsx` - colored chip with icon for cards and group headers
- `ui/src/components/CategoryManagementDialog.tsx` - full management dialog with color/icon pickers

### Modified files

- `ui/src/App.tsx` - Categories button, updated export/import
- `ui/src/components/RunbookFormDialog.tsx` - category dropdown with color swatches
- `ui/src/components/RunbookCard.tsx` - displays CategoryBadge
- `ui/src/components/RunbookList.tsx` - group-by-category mode, category search
- `ui/src/storage.ts` - category persistence, backwards-compatible import
- `ui/src/index.tsx` - CategoryProvider wrapper

## Test plan

- [ ] Create, edit, reorder, and delete categories via management dialog
- [ ] Assign a category to a runbook in create/edit form
- [ ] Verify group cycling: none -> tag -> category
- [ ] Verify category groups show colored headers with icon badges
- [ ] Import an old-format export file and confirm it still works
- [ ] Search by category name and verify matching

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)