### PR TITLE
fix: UI polish — tighter grouping, card padding, docker prefix support

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,6 +5,7 @@ import AddIcon from "@mui/icons-material/Add";
 import DownloadIcon from "@mui/icons-material/Download";
 import UploadIcon from "@mui/icons-material/Upload";
 import SettingsIcon from "@mui/icons-material/Settings";
+import RestoreIcon from "@mui/icons-material/Restore";
 import { RunbookList } from "./components/RunbookList";
 import { RunbookFormDialog } from "./components/RunbookFormDialog";
 import { CategoryManagementDialog } from "./components/CategoryManagementDialog";
@@ -19,7 +20,7 @@ export function useDockerDesktopClient() {
 }
 
 export default function App() {
-  const { runbooks, replaceAll } = useRunbooks();
+  const { runbooks, replaceAll, restoreDefaults } = useRunbooks();
   const { categories, replaceAllCategories } = useCategories();
   const [formOpen, setFormOpen] = useState(false);
   const [categoryDialogOpen, setCategoryDialogOpen] = useState(false);
@@ -60,6 +61,16 @@ export default function App() {
       >
         <Typography variant="h3">Runbooks</Typography>
         <Stack direction="row" spacing={1}>
+          <Button size="small" startIcon={<RestoreIcon />} onClick={() => {
+            const count = restoreDefaults();
+            if (count > 0) {
+              ddClient.desktopUI.toast.success(`Restored ${count} example runbooks`);
+            } else {
+              ddClient.desktopUI.toast.success("All example runbooks already present");
+            }
+          }}>
+            Examples
+          </Button>
           <Button size="small" startIcon={<SettingsIcon />} onClick={() => setCategoryDialogOpen(true)}>
             Categories
           </Button>

--- a/ui/src/components/CommandEditor.tsx
+++ b/ui/src/components/CommandEditor.tsx
@@ -25,11 +25,16 @@ function highlightDocker(code: string): string {
       let result = "";
       let remaining = escaped;
       const tokens = trimmed.split(/\s+/);
-      const firstToken = tokens[0].toLowerCase();
 
-      // Check if first token is a known command or management command
-      const isKnownCommand = ALL_COMMANDS.has(firstToken);
-      const isMgmtCommand = MANAGEMENT_COMMANDS.has(firstToken);
+      // Handle optional "docker" prefix — treat it as a neutral keyword
+      let cmdOffset = 0;
+      if (tokens[0].toLowerCase() === "docker" && tokens.length > 1) {
+        cmdOffset = 1;
+      }
+
+      const cmdToken = tokens[cmdOffset]?.toLowerCase() ?? "";
+      const isKnownCommand = ALL_COMMANDS.has(cmdToken);
+      const isMgmtCommand = MANAGEMENT_COMMANDS.has(cmdToken);
 
       for (let i = 0; i < tokens.length; i++) {
         const token = escapeHtml(tokens[i]);
@@ -39,26 +44,24 @@ function highlightDocker(code: string): string {
         }
         remaining = remaining.slice(tokenIdx + token.length);
 
-        if (i === 0 && isKnownCommand) {
-          // First token: known command (blue)
+        if (i < cmdOffset) {
+          // "docker" prefix — dim keyword
+          result += `<span style="color:var(--docker-comment)">${token}</span>`;
+        } else if (i === cmdOffset && isKnownCommand) {
           result += `<span style="color:var(--docker-command)">${token}</span>`;
-        } else if (i === 1 && isMgmtCommand) {
-          // Second token after management command: sub-command
-          const subs = DOCKER_COMMANDS[firstToken]?.subcommands;
-          const isValidSub = subs && tokens[1].toLowerCase() in subs;
+        } else if (i === cmdOffset + 1 && isMgmtCommand) {
+          const subs = DOCKER_COMMANDS[cmdToken]?.subcommands;
+          const isValidSub = subs && tokens[i].toLowerCase() in subs;
           if (isValidSub) {
             result += `<span style="color:var(--docker-subcommand)">${token}</span>`;
           } else {
             result += `<span style="color:var(--docker-unknown);text-decoration:wavy underline var(--docker-unknown)">${token}</span>`;
           }
-        } else if (i === 0 && !isKnownCommand && trimmed.length > 0) {
-          // Unknown first token
+        } else if (i === cmdOffset && !isKnownCommand) {
           result += `<span style="color:var(--docker-unknown);text-decoration:wavy underline var(--docker-unknown)">${token}</span>`;
         } else if (/^--?[a-zA-Z]/.test(tokens[i])) {
-          // Flags
           result += `<span style="color:var(--docker-flag)">${token}</span>`;
         } else if (/^["']/.test(tokens[i])) {
-          // Quoted strings
           result += `<span style="color:var(--docker-string)">${token}</span>`;
         } else {
           result += token;
@@ -121,7 +124,7 @@ export function CommandEditor({ value, onChange }: CommandEditorProps) {
         />
       </Box>
       <FormHelperText>
-        Each line is a Docker command, e.g. &apos;container prune -f&apos;
+        Paste Docker commands directly — &quot;docker&quot; prefix is optional
       </FormHelperText>
     </Box>
   );

--- a/ui/src/components/RunbookCard.tsx
+++ b/ui/src/components/RunbookCard.tsx
@@ -36,7 +36,7 @@ export function RunbookCard({ runbook, category, collapsed = false, onToggleColl
   return (
     <>
       <Card variant="outlined">
-        <CardContent sx={{ p: compact ? 1 : 1.5, "&:last-child": { pb: compact ? 1 : 1.5 } }}>
+        <CardContent sx={{ p: compact ? 0.75 : 1, "&:last-child": { pb: compact ? 0.75 : 1 } }}>
           <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: collapsed ? 0 : 0.5 }}>
             {onToggleCollapse && (
               <IconButton size="small" onClick={onToggleCollapse} title={collapsed ? "Expand" : "Collapse"}>

--- a/ui/src/components/RunbookFormDialog.tsx
+++ b/ui/src/components/RunbookFormDialog.tsx
@@ -39,10 +39,6 @@ function validateCommands(raw: string): string[] {
     if (!line || line.startsWith("#")) continue;
 
     // Phase 1: Basic pattern checks
-    if (/^docker\s+/i.test(line)) {
-      warnings.push(`Line ${i + 1}: Remove leading "docker" — the extension adds it automatically.`);
-      continue;
-    }
     if (/[;&|]/.test(line)) {
       warnings.push(`Line ${i + 1}: Shell operators (;, &, |) may not work. Use separate lines instead.`);
     }
@@ -50,8 +46,9 @@ function validateCommands(raw: string): string[] {
       warnings.push(`Line ${i + 1}: Variable substitution ($VAR) is not supported.`);
     }
 
-    // Phase 2: Command tree validation
-    const tokens = line.split(/\s+/);
+    // Strip optional "docker" prefix for command tree validation
+    const stripped = line.replace(/^docker\s+/i, "");
+    const tokens = stripped.split(/\s+/);
     const cmd = tokens[0].toLowerCase();
 
     if (!ALL_COMMANDS.has(cmd)) {
@@ -69,7 +66,6 @@ function validateCommands(raw: string): string[] {
       const subs = DOCKER_COMMANDS[cmd].subcommands;
       if (subs && tokens.length > 1) {
         const sub = tokens[1].toLowerCase();
-        // Skip if it looks like a flag (e.g., compose --file)
         if (!sub.startsWith("-") && !(sub in subs)) {
           const subSuggestion = findClosest(sub, Object.keys(subs));
           if (subSuggestion) {
@@ -199,6 +195,9 @@ export function RunbookFormDialog({ open, onClose, runbook }: RunbookFormDialogP
               Commands (one per line) *
             </Typography>
             <CommandEditor value={commands} onChange={setCommands} />
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: "block" }}>
+              Paste commands directly from terminals or docs. The &quot;docker&quot; prefix is optional.
+            </Typography>
           </div>
           {commandWarnings.length > 0 && (
             <Alert severity="warning" sx={{ py: 0, "& .MuiAlert-message": { fontSize: "0.8rem" } }}>

--- a/ui/src/components/RunbookList.tsx
+++ b/ui/src/components/RunbookList.tsx
@@ -31,7 +31,7 @@ import { RunbookCard } from "./RunbookCard";
 import { CategoryBadge } from "./CategoryBadge";
 
 const getLayoutSx = (mode: LayoutMode, compact: boolean) => {
-  const gap = compact ? 1 : 1.5;
+  const gap = compact ? 0.5 : 1;
   if (mode === "list") {
     return { display: "flex", flexDirection: "column" as const, gap, alignContent: "start" };
   }
@@ -43,18 +43,12 @@ const getLayoutSx = (mode: LayoutMode, compact: boolean) => {
   };
 };
 
-interface SubGroup {
-  tag: string;
-  runbooks: Runbook[];
-}
-
 interface PrimaryGroup {
   tag: string;
   color?: string;
   icon?: string;
   category?: Category;
-  direct: Runbook[];
-  subgroups: SubGroup[];
+  runbooks: Runbook[];
 }
 
 export function RunbookList() {
@@ -140,51 +134,45 @@ export function RunbookList() {
           color: cat.color,
           icon: cat.icon,
           category: cat,
-          direct: catGroups.get(cat.id) ?? [],
-          subgroups: [],
+          runbooks: catGroups.get(cat.id) ?? [],
         }));
 
       if (ungrouped.length > 0) {
-        result.push({ tag: "Uncategorized", direct: ungrouped, subgroups: [] });
+        result.push({ tag: "Uncategorized", runbooks: ungrouped });
       }
       return result;
     }
 
-    // groupMode === "tag"
-    const primaryMap = new Map<string, { direct: Runbook[]; subs: Map<string, Runbook[]> }>();
+    // groupMode === "tag" — group by first tag (case-insensitive), sort within by remaining tags
+    const primaryMap = new Map<string, { display: string; items: Runbook[] }>();
     const ungrouped: Runbook[] = [];
 
     for (const r of sorted) {
       if (r.tags.length === 0) {
         ungrouped.push(r);
       } else {
-        const primary = r.tags[0];
-        if (!primaryMap.has(primary)) {
-          primaryMap.set(primary, { direct: [], subs: new Map() });
+        const key = r.tags[0].trim().toLowerCase();
+        if (!primaryMap.has(key)) {
+          primaryMap.set(key, { display: r.tags[0].trim(), items: [] });
         }
-        const group = primaryMap.get(primary)!;
-        if (r.tags.length >= 2) {
-          const sub = r.tags[1];
-          if (!group.subs.has(sub)) group.subs.set(sub, []);
-          group.subs.get(sub)!.push(r);
-        } else {
-          group.direct.push(r);
-        }
+        primaryMap.get(key)!.items.push(r);
       }
     }
 
+    // Within each group, sort by secondary tags then name
     const result: PrimaryGroup[] = [...primaryMap.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([tag, { direct, subs }]) => ({
-        tag,
-        direct,
-        subgroups: [...subs.entries()]
-          .sort(([a], [b]) => a.localeCompare(b))
-          .map(([subTag, subRunbooks]) => ({ tag: subTag, runbooks: subRunbooks })),
+      .map(([, { display, items }]) => ({
+        tag: display,
+        runbooks: items.sort((a, b) => {
+          const aSub = a.tags.slice(1).join("/");
+          const bSub = b.tags.slice(1).join("/");
+          return aSub.localeCompare(bSub) || a.name.localeCompare(b.name);
+        }),
       }));
 
     if (ungrouped.length > 0) {
-      result.push({ tag: "Ungrouped", direct: ungrouped, subgroups: [] });
+      result.push({ tag: "Ungrouped", runbooks: ungrouped });
     }
     return result;
   }, [sorted, groupMode, categories, categoryMap]);
@@ -244,8 +232,7 @@ export function RunbookList() {
   const expandAllCards = () => setCollapsedCards(new Set());
   const collapseAllCards = () => setCollapsedCards(new Set(sorted.map((r) => r.id)));
 
-  const totalInGroup = (g: PrimaryGroup) =>
-    g.direct.length + g.subgroups.reduce((sum, s) => sum + s.runbooks.length, 0);
+  const totalInGroup = (g: PrimaryGroup) => g.runbooks.length;
 
   const groupLabel = groupMode === "none" ? "Group" : groupMode === "tag" ? "By Tag" : "By Category";
 
@@ -360,71 +347,41 @@ export function RunbookList() {
         </Box>
       ) : groups ? (
         <Box sx={{ flex: 1, overflow: "auto" }}>
-          <Stack spacing={2}>
+          <Stack spacing={0.75}>
             {groups.map((group) => (
               <Box key={group.tag}>
-                {/* Group header */}
                 <Stack
                   direction="row"
                   alignItems="center"
                   spacing={0.5}
                   onClick={() => toggleCollapse(group.tag)}
-                  sx={{ cursor: "pointer", mb: 0.5, userSelect: "none" }}
+                  sx={{
+                    cursor: "pointer",
+                    userSelect: "none",
+                    py: 0.25,
+                    borderBottom: 1,
+                    borderColor: "divider",
+                  }}
                 >
-                  <IconButton size="small">
-                    {collapsed.has(group.tag) ? (
-                      <ExpandMoreIcon fontSize="small" />
-                    ) : (
-                      <ExpandLessIcon fontSize="small" />
-                    )}
-                  </IconButton>
+                  {collapsed.has(group.tag) ? (
+                    <ExpandMoreIcon sx={{ fontSize: "1rem", color: "text.secondary" }} />
+                  ) : (
+                    <ExpandLessIcon sx={{ fontSize: "1rem", color: "text.secondary" }} />
+                  )}
                   {group.category ? (
                     <CategoryBadge category={group.category} />
                   ) : (
-                    <Chip label={group.tag} size="small" />
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      {group.tag}
+                    </Typography>
                   )}
-                  <Typography variant="body2" color="text.secondary">
-                    ({totalInGroup(group)})
+                  <Typography variant="caption" color="text.secondary">
+                    {totalInGroup(group)}
                   </Typography>
                 </Stack>
                 <Collapse in={!collapsed.has(group.tag)}>
-                  <Box sx={{ pl: 2 }}>
-                    {group.direct.length > 0 && (
-                      <Box sx={{ ...layoutSx, mb: group.subgroups.length > 0 ? 1.5 : 0 }}>
-                        {group.direct.map(renderCard)}
-                      </Box>
-                    )}
-                    {group.subgroups.map((sub) => {
-                      const subKey = `${group.tag}/${sub.tag}`;
-                      return (
-                        <Box key={subKey} sx={{ mb: 1 }}>
-                          <Stack
-                            direction="row"
-                            alignItems="center"
-                            spacing={0.5}
-                            onClick={() => toggleCollapse(subKey)}
-                            sx={{ cursor: "pointer", mb: 0.5, userSelect: "none" }}
-                          >
-                            <IconButton size="small">
-                              {collapsed.has(subKey) ? (
-                                <ExpandMoreIcon sx={{ fontSize: "1rem" }} />
-                              ) : (
-                                <ExpandLessIcon sx={{ fontSize: "1rem" }} />
-                              )}
-                            </IconButton>
-                            <Chip label={sub.tag} size="small" variant="outlined" />
-                            <Typography variant="body2" color="text.secondary">
-                              ({sub.runbooks.length})
-                            </Typography>
-                          </Stack>
-                          <Collapse in={!collapsed.has(subKey)}>
-                            <Box sx={{ ...layoutSx, pl: 2 }}>
-                              {sub.runbooks.map(renderCard)}
-                            </Box>
-                          </Collapse>
-                        </Box>
-                      );
-                    })}
+                  <Box sx={{ ...layoutSx, pl: 1, pt: 0.5 }}>
+                    {group.runbooks.map(renderCard)}
                   </Box>
                 </Collapse>
               </Box>

--- a/ui/src/context/RunbookContext.tsx
+++ b/ui/src/context/RunbookContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
 import type { Runbook } from "../types";
-import { loadRunbooks, saveRunbooks } from "../storage";
+import { loadRunbooks, saveRunbooks, getMissingDefaults } from "../storage";
 
 interface RunbookContextValue {
   runbooks: Runbook[];
@@ -8,6 +8,7 @@ interface RunbookContextValue {
   updateRunbook: (id: string, updates: Partial<Omit<Runbook, "id" | "createdAt">>) => void;
   deleteRunbook: (id: string) => void;
   replaceAll: (runbooks: Runbook[]) => void;
+  restoreDefaults: () => number;
 }
 
 const RunbookContext = createContext<RunbookContextValue | null>(null);
@@ -59,8 +60,20 @@ export function RunbookProvider({ children }: { children: ReactNode }) {
     setRunbooks(imported);
   }, []);
 
+  const restoreDefaults = useCallback((): number => {
+    const missing = getMissingDefaults(runbooks);
+    if (missing.length > 0) {
+      setRunbooks((prev) => {
+        const next = [...missing, ...prev];
+        saveRunbooks(next);
+        return next;
+      });
+    }
+    return missing.length;
+  }, [runbooks]);
+
   return (
-    <RunbookContext.Provider value={{ runbooks, addRunbook, updateRunbook, deleteRunbook, replaceAll }}>
+    <RunbookContext.Provider value={{ runbooks, addRunbook, updateRunbook, deleteRunbook, replaceAll, restoreDefaults }}>
       {children}
     </RunbookContext.Provider>
   );

--- a/ui/src/storage.ts
+++ b/ui/src/storage.ts
@@ -5,13 +5,13 @@ const STORAGE_KEY = "runbooks-data";
 const CATEGORIES_KEY = "runbooks-categories";
 const PREFS_KEY = "runbooks-prefs";
 
-const DEFAULT_RUNBOOKS: Runbook[] = [
+export const DEFAULT_RUNBOOKS: Runbook[] = [
   {
     id: "example-1",
     name: "Running Containers",
     description: "Show all running containers with key details",
     commands: [
-      'ps --format "table {{.Names}}\\t{{.Image}}\\t{{.Status}}\\t{{.Ports}}"',
+      'docker ps --format "table {{.Names}}\\t{{.Image}}\\t{{.Status}}\\t{{.Ports}}"',
     ],
     tags: ["info"],
     createdAt: "2026-01-01T00:00:00Z",
@@ -21,7 +21,7 @@ const DEFAULT_RUNBOOKS: Runbook[] = [
     id: "example-2",
     name: "Disk Usage",
     description: "Check how much disk space Docker is using",
-    commands: ["system df"],
+    commands: ["docker system df"],
     tags: ["info"],
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
@@ -30,7 +30,7 @@ const DEFAULT_RUNBOOKS: Runbook[] = [
     id: "example-3",
     name: "Quick Cleanup",
     description: "Remove stopped containers and dangling images",
-    commands: ["container prune -f", "image prune -f"],
+    commands: ["docker container prune -f", "docker image prune -f"],
     tags: ["cleanup"],
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
@@ -39,7 +39,7 @@ const DEFAULT_RUNBOOKS: Runbook[] = [
     id: "example-4",
     name: "Full Reset",
     description: "Remove all unused containers, networks, images, and volumes",
-    commands: ["system prune -af --volumes"],
+    commands: ["docker system prune -af --volumes"],
     tags: ["cleanup", "caution"],
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
@@ -48,7 +48,7 @@ const DEFAULT_RUNBOOKS: Runbook[] = [
     id: "example-5",
     name: "Network Overview",
     description: "List all Docker networks",
-    commands: ["network ls"],
+    commands: ["docker network ls"],
     tags: ["info"],
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
@@ -58,8 +58,8 @@ const DEFAULT_RUNBOOKS: Runbook[] = [
     name: "Volume Inventory",
     description: "List all volumes and check for dangling ones",
     commands: [
-      "volume ls",
-      'volume ls --filter "dangling=true"',
+      "docker volume ls",
+      'docker volume ls --filter "dangling=true"',
     ],
     tags: ["info"],
     createdAt: "2026-01-01T00:00:00Z",
@@ -105,6 +105,11 @@ export function exportRunbooks(runbooks: Runbook[], categories?: Category[]): vo
   a.download = `runbooks-${new Date().toISOString().slice(0, 10)}.json`;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+export function getMissingDefaults(current: Runbook[]): Runbook[] {
+  const ids = new Set(current.map((r) => r.id));
+  return DEFAULT_RUNBOOKS.filter((r) => !ids.has(r.id));
 }
 
 export function loadPreference<T>(key: string, fallback: T): T {


### PR DESCRIPTION
## Summary

- Reduce card padding for tighter density (compact: 0.75rem, normal: 1rem)
- Flatten tag grouping: remove sub-group headers, cards flow directly under primary group sorted by secondary tags
- Case-insensitive tag grouping — "project1" and "Project1" merge into one group
- Accept full `docker` CLI commands — prefix is optional, dimmed in syntax highlighter, stripped at execution time
- Add "Examples" button to restore pre-seeded default runbooks without duplicating existing ones
- Update default runbooks to use full `docker` commands for copy-paste readiness

Closes #11

## Test plan

- [ ] Verify tag grouping merges different-cased tags into one group
- [ ] Create runbooks with full `docker` prefix — no validation warning
- [ ] Click "Examples" to restore defaults, verify no duplicates
- [ ] Test compact and normal density card padding
- [ ] Verify export produces CLI-ready `docker` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)