### PR TITLE
chore: add editorconfig and gitignore .claude/ directory

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+# EditorConfig helps maintain consistent coding styles
+# https://editorconfig.org
+
+root = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code local settings
+.claude/
+
 # Dependencies
 ui/node_modules/
 


### PR DESCRIPTION
## Summary
- Adds `.editorconfig` with `root = false` to inherit formatting rules from the DevSpace parent directory
- Adds `.claude/` to `.gitignore` to prevent local Claude Code settings from being committed

## Test plan
- [x] Verify `.claude/settings.local.json` no longer shows in `git status` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)