### PR TITLE
feat: add user feedback and support links with diagnostic review

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,17 +1,29 @@
 import { useState, useRef } from "react";
 import { createDockerDesktopClient } from "@docker/extension-api-client";
-import { Box, Typography, Stack, Button } from "@mui/material";
+import {
+  Box, Typography, Stack, Button, IconButton, Tooltip,
+  Menu, MenuItem, Divider, ListItemIcon, ListItemText,
+} from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import DownloadIcon from "@mui/icons-material/Download";
 import UploadIcon from "@mui/icons-material/Upload";
 import SettingsIcon from "@mui/icons-material/Settings";
 import RestoreIcon from "@mui/icons-material/Restore";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import BugReportIcon from "@mui/icons-material/BugReport";
+import LightbulbIcon from "@mui/icons-material/Lightbulb";
+import FeedbackIcon from "@mui/icons-material/Feedback";
+import GitHubIcon from "@mui/icons-material/GitHub";
+import FavoriteIcon from "@mui/icons-material/Favorite";
 import { RunbookList } from "./components/RunbookList";
 import { RunbookFormDialog } from "./components/RunbookFormDialog";
 import { CategoryManagementDialog } from "./components/CategoryManagementDialog";
+import { DiagnosticDialog } from "./components/DiagnosticDialog";
 import { useRunbooks } from "./context/RunbookContext";
 import { useCategories } from "./context/CategoryContext";
 import { exportRunbooks, importRunbooks } from "./storage";
+
+const REPO_URL = "https://github.com/HerbHall/Runbooks";
 
 const ddClient = createDockerDesktopClient();
 
@@ -24,6 +36,8 @@ export default function App() {
   const { categories, replaceAllCategories } = useCategories();
   const [formOpen, setFormOpen] = useState(false);
   const [categoryDialogOpen, setCategoryDialogOpen] = useState(false);
+  const [helpAnchor, setHelpAnchor] = useState<null | HTMLElement>(null);
+  const [diagnosticType, setDiagnosticType] = useState<"bug" | "feature" | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleExport = () => {
@@ -82,6 +96,38 @@ export default function App() {
           <Button size="small" startIcon={<UploadIcon />} onClick={handleImportClick}>
             Import
           </Button>
+          <Tooltip title="Help & Feedback">
+            <IconButton size="small" onClick={(e) => setHelpAnchor(e.currentTarget)}>
+              <HelpOutlineIcon />
+            </IconButton>
+          </Tooltip>
+          <Menu
+            anchorEl={helpAnchor}
+            open={Boolean(helpAnchor)}
+            onClose={() => setHelpAnchor(null)}
+          >
+            <MenuItem onClick={() => { setDiagnosticType("bug"); setHelpAnchor(null); }}>
+              <ListItemIcon><BugReportIcon fontSize="small" /></ListItemIcon>
+              <ListItemText>Report a Bug</ListItemText>
+            </MenuItem>
+            <MenuItem onClick={() => { setDiagnosticType("feature"); setHelpAnchor(null); }}>
+              <ListItemIcon><LightbulbIcon fontSize="small" /></ListItemIcon>
+              <ListItemText>Request a Feature</ListItemText>
+            </MenuItem>
+            <MenuItem onClick={() => { ddClient.host.openExternal(`${REPO_URL}/issues/new?template=feedback.yml`); setHelpAnchor(null); }}>
+              <ListItemIcon><FeedbackIcon fontSize="small" /></ListItemIcon>
+              <ListItemText>Send Feedback</ListItemText>
+            </MenuItem>
+            <Divider />
+            <MenuItem onClick={() => { ddClient.host.openExternal(REPO_URL); setHelpAnchor(null); }}>
+              <ListItemIcon><GitHubIcon fontSize="small" /></ListItemIcon>
+              <ListItemText>View on GitHub</ListItemText>
+            </MenuItem>
+            <MenuItem onClick={() => { ddClient.host.openExternal("https://github.com/sponsors/HerbHall"); setHelpAnchor(null); }}>
+              <ListItemIcon><FavoriteIcon fontSize="small" /></ListItemIcon>
+              <ListItemText>Support this Project</ListItemText>
+            </MenuItem>
+          </Menu>
           <Button variant="contained" startIcon={<AddIcon />} onClick={() => setFormOpen(true)}>
             New Runbook
           </Button>
@@ -91,15 +137,47 @@ export default function App() {
       <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
         Saved command scripts for Docker Desktop. Create, organize, and execute
         Docker commands with one click.
-        <Typography component="span" variant="caption" color="text.disabled" sx={{ ml: 1 }}>
-          v{__APP_VERSION__}
-        </Typography>
       </Typography>
 
       <RunbookList />
 
+      <Stack
+        direction="row"
+        spacing={1}
+        justifyContent="center"
+        alignItems="center"
+        sx={{ mt: "auto", pt: 1, pb: 0.5 }}
+      >
+        {[
+          { label: "Feedback", url: `${REPO_URL}/issues/new?template=feedback.yml` },
+          { label: "GitHub", url: REPO_URL },
+          { label: "Support", url: "https://github.com/sponsors/HerbHall" },
+        ].map((link, i) => (
+          <Stack key={link.label} direction="row" spacing={1} alignItems="center">
+            {i > 0 && <Typography variant="caption" color="text.disabled">·</Typography>}
+            <Typography
+              variant="caption"
+              color="text.disabled"
+              sx={{ cursor: "pointer", "&:hover": { textDecoration: "underline", color: "text.secondary" } }}
+              onClick={() => ddClient.host.openExternal(link.url)}
+            >
+              {link.label}
+            </Typography>
+          </Stack>
+        ))}
+        <Typography variant="caption" color="text.disabled">·</Typography>
+        <Typography variant="caption" color="text.disabled">
+          v{__APP_VERSION__}
+        </Typography>
+      </Stack>
+
       <RunbookFormDialog open={formOpen} onClose={() => setFormOpen(false)} />
       <CategoryManagementDialog open={categoryDialogOpen} onClose={() => setCategoryDialogOpen(false)} />
+      <DiagnosticDialog
+        open={diagnosticType !== null}
+        onClose={() => setDiagnosticType(null)}
+        type={diagnosticType ?? "bug"}
+      />
 
       <input
         ref={fileInputRef}

--- a/ui/src/components/DiagnosticDialog.tsx
+++ b/ui/src/components/DiagnosticDialog.tsx
@@ -1,0 +1,154 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  FormControlLabel,
+  Checkbox,
+  Box,
+} from "@mui/material";
+import { useDockerDesktopClient } from "../App";
+
+const REPO_URL = "https://github.com/HerbHall/Runbooks";
+
+interface DiagnosticDialogProps {
+  open: boolean;
+  onClose: () => void;
+  type: "bug" | "feature";
+}
+
+interface DiagnosticInfo {
+  extensionVersion: string;
+  platform: string;
+  arch: string;
+  dockerVersion: string;
+}
+
+function mapPlatformToOS(platform: string): string {
+  switch (platform) {
+    case "win32": return "Windows";
+    case "darwin": return "macOS";
+    case "linux": return "Linux";
+    default: return platform;
+  }
+}
+
+export function DiagnosticDialog({ open, onClose, type }: DiagnosticDialogProps) {
+  const ddClient = useDockerDesktopClient();
+  const [includeDiagnostics, setIncludeDiagnostics] = useState(true);
+  const [diagnostics, setDiagnostics] = useState<DiagnosticInfo | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const gather = async () => {
+      let dockerVersion = "unknown";
+      try {
+        const result = await ddClient.docker.cli.exec("version", [
+          "--format", "{{.Client.Version}}",
+        ]);
+        dockerVersion = result.stdout.trim();
+      } catch {
+        // fall back to "unknown"
+      }
+      setDiagnostics({
+        extensionVersion: __APP_VERSION__,
+        platform: ddClient.host.platform,
+        arch: ddClient.host.arch,
+        dockerVersion,
+      });
+    };
+    gather();
+  }, [open, ddClient]);
+
+  const diagnosticText = diagnostics
+    ? [
+        `Extension: v${diagnostics.extensionVersion}`,
+        `Platform:  ${mapPlatformToOS(diagnostics.platform)} (${diagnostics.arch})`,
+        `Docker:    ${diagnostics.dockerVersion}`,
+      ].join("\n")
+    : "Gathering...";
+
+  const handleContinue = () => {
+    let url: string;
+    if (type === "bug") {
+      if (includeDiagnostics && diagnostics) {
+        const dockerField = `Docker Desktop ${diagnostics.dockerVersion}, Extension v${diagnostics.extensionVersion}`;
+        const osField = mapPlatformToOS(diagnostics.platform);
+        const params = new URLSearchParams({
+          template: "bug_report.yml",
+          "docker-version": dockerField,
+          os: osField,
+        });
+        url = `${REPO_URL}/issues/new?${params.toString()}`;
+      } else {
+        url = `${REPO_URL}/issues/new?template=bug_report.yml`;
+      }
+    } else {
+      if (includeDiagnostics && diagnostics) {
+        const footer = `Extension v${diagnostics.extensionVersion} | ${mapPlatformToOS(diagnostics.platform)} ${diagnostics.arch} | Docker ${diagnostics.dockerVersion}`;
+        const params = new URLSearchParams({
+          template: "feature_request.yml",
+          problem: `\n\n---\n${footer}`,
+        });
+        url = `${REPO_URL}/issues/new?${params.toString()}`;
+      } else {
+        url = `${REPO_URL}/issues/new?template=feature_request.yml`;
+      }
+    }
+    ddClient.host.openExternal(url);
+    onClose();
+  };
+
+  const title = type === "bug" ? "Report a Bug" : "Request a Feature";
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Review the diagnostic information below. This helps us troubleshoot
+          but is entirely optional.
+        </Typography>
+        {includeDiagnostics && (
+          <Box
+            component="pre"
+            sx={{
+              p: 1.5,
+              borderRadius: 1,
+              bgcolor: "action.hover",
+              fontSize: "0.8rem",
+              fontFamily: "monospace",
+              whiteSpace: "pre",
+              overflow: "auto",
+              m: 0,
+              mb: 2,
+            }}
+          >
+            {diagnosticText}
+          </Box>
+        )}
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={includeDiagnostics}
+              onChange={(e) => setIncludeDiagnostics(e.target.checked)}
+              size="small"
+            />
+          }
+          label={
+            <Typography variant="body2">Include diagnostic information</Typography>
+          }
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" onClick={handleContinue}>
+          Continue to GitHub
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

- Add help/feedback icon button to toolbar with dropdown menu
- Menu items: Report a Bug, Request a Feature, Send Feedback, View on GitHub, Support this Project
- Bug reports and feature requests show a diagnostic review dialog before opening GitHub
- Dialog displays extension version, platform, architecture, and Docker version
- Users can uncheck "Include diagnostic information" for privacy
- Footer links (Feedback, GitHub, Support, version) always visible at bottom
- All external links use `ddClient.host.openExternal()` per Docker Extension SDK

## Diagnostic Review

When reporting a bug or requesting a feature, users see a dialog showing exactly what diagnostic data will be shared:

```text
Extension: v0.1.0
Platform:  Windows (x64)
Docker:    27.5.1
```

A checkbox lets them opt out — unchecking opens the GitHub form without any pre-filled data.

## Test plan

- [ ] Help icon visible in toolbar
- [ ] Menu opens with 5 items on click
- [ ] "Report a Bug" shows diagnostic review dialog
- [ ] "Request a Feature" shows diagnostic review dialog
- [ ] Diagnostic data displays correctly (version, platform, Docker version)
- [ ] Unchecking "Include diagnostic information" hides the preview
- [ ] "Continue to GitHub" opens pre-filled issue form in browser
- [ ] "Send Feedback", "View on GitHub", "Support" open URLs directly
- [ ] Footer links visible and functional
- [ ] Version moved from subtitle to footer

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)