### PR TITLE
docs: add community health files and contributor guidelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files
+* @HerbHall

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- Brief description of what this PR does and why -->
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactoring (no behavior change)
+- [ ] Documentation
+- [ ] CI/Build configuration
+
+## Checklist
+
+- [ ] `npm run build` passes (from `ui/`)
+- [ ] `npm run lint` passes (from `ui/`)
+- [ ] Changes follow existing code patterns
+- [ ] Self-reviewed the diff before submitting

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,125 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement via
+[GitHub Issues](https://github.com/HerbHall/Runbooks/issues).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to Runbooks
+
+Thanks for your interest in contributing! This guide covers everything you need to get started.
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) 4.x or later
+- [Node.js](https://nodejs.org/) 22 or later (npm is bundled)
+- Git
+
+## Development Setup
+
+```bash
+# Clone and install
+git clone https://github.com/HerbHall/Runbooks.git
+cd Runbooks/ui
+npm install
+
+# Start hot-reload dev server
+npm run dev
+
+# In another terminal — build, install, and attach to dev server
+cd Runbooks
+make build-extension
+make install-extension
+make dev-attach
+```
+
+See the [Makefile](Makefile) for all available targets (`make build-extension`, `make validate-extension`, `make dev-reset`, etc.).
+
+## Making Changes
+
+### Find or Create an Issue
+
+Every change should be tied to a GitHub issue. Check [existing issues](https://github.com/HerbHall/Runbooks/issues) first, or open a new one using the issue templates.
+
+### Branch Naming
+
+Create a branch from `main` using this convention:
+
+- `feature/issue-NNN-short-desc` — new features
+- `fix/issue-NNN-short-desc` — bug fixes
+- `chore/issue-NNN-short-desc` — maintenance tasks
+- `docs/issue-NNN-short-desc` — documentation changes
+
+### Commit Messages
+
+This project uses [conventional commits](https://www.conventionalcommits.org/):
+
+- `feat:` new features
+- `fix:` bug fixes
+- `refactor:` code restructuring (no behavior change)
+- `docs:` documentation only
+- `test:` adding or updating tests
+- `chore:` maintenance, dependencies, CI
+
+### Code Style
+
+- TypeScript strict mode is enforced
+- ESLint is configured — run `npm run lint` before submitting
+- 2-space indentation (enforced by EditorConfig)
+- Material UI components to match Docker Desktop's theme
+- No Go backend — all Docker interaction uses the Extension SDK's `docker.cli.exec()`
+
+### Before Submitting
+
+From the `ui/` directory, verify your changes pass all checks:
+
+```bash
+npm run lint       # ESLint
+npm run typecheck  # TypeScript strict checking
+npm run build      # Full build
+```
+
+## Pull Request Process
+
+1. Fork the repo and create your branch from `main`
+2. Make your changes and verify checks pass (see above)
+3. Push your branch and open a PR against `main`
+4. Fill out the PR template — link the related issue
+5. CI must pass before merge
+6. PRs are squash-merged to keep a clean history
+
+## Architecture Overview
+
+Runbooks is a **frontend-only** Docker Desktop Extension. There is no backend service.
+
+- `ui/src/components/` — React components
+- `ui/src/context/` — React context providers (RunbookContext, CategoryContext)
+- `ui/src/storage.ts` — localStorage CRUD and import/export
+- `ui/src/docker-commands.ts` — Command validation rules and syntax data
+- `ui/src/types.ts` — TypeScript type definitions
+
+All Docker interaction goes through the Extension SDK client initialized in `App.tsx`. See `docs/decisions/` for Architecture Decision Records.
+
+## Reporting Issues
+
+Use the [issue templates](https://github.com/HerbHall/Runbooks/issues/new/choose) for bug reports, feature requests, or general feedback.
+
+For security vulnerabilities, see [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Runbooks
 
+[![CI](https://github.com/HerbHall/Runbooks/actions/workflows/ci.yml/badge.svg)](https://github.com/HerbHall/Runbooks/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 **Saved command scripts for Docker Desktop.**
 
 A Docker Desktop Extension that lets you create, organize, and execute Docker command scripts with one click. Think of it as a personal runbook library built right into Docker Desktop.
@@ -65,6 +68,12 @@ make dev-attach
 Frontend-only Docker Desktop Extension built with React, TypeScript, and Material UI. Uses the Docker Extension SDK's `docker.cli.exec()` to run commands directly — no backend service required.
 
 See `docs/decisions/` for Architecture Decision Records documenting all technical choices.
+
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+
+Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x | Yes |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities through GitHub's private vulnerability reporting:
+
+1. Go to the [Security tab](https://github.com/HerbHall/Runbooks/security/advisories)
+2. Click **Report a vulnerability**
+3. Fill out the form with details about the issue
+
+**Do not open a public issue for security vulnerabilities.**
+
+## Response Timeline
+
+- **Acknowledgment:** within 7 days
+- **Status update:** within 30 days
+- **Fix timeline:** depends on severity and complexity
+
+## Scope
+
+This extension runs Docker CLI commands on behalf of the user through the Docker Desktop Extension SDK. Security-relevant areas include:
+
+- Command injection via runbook command fields
+- Import/export file handling
+- localStorage data integrity


### PR DESCRIPTION
## Summary

Add contributor-facing documentation and configuration files to make the repo ready for external contributors.

**Files added:**
- `CONTRIBUTING.md` — dev setup, branch naming, commit format, PR process, code style, architecture overview
- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
- `SECURITY.md` — private vulnerability reporting via GitHub Security tab
- `.github/pull_request_template.md` — PR structure with type-of-change checkboxes and checklist
- `.github/CODEOWNERS` — auto-assigns @HerbHall as reviewer on all PRs

**Files modified:**
- `README.md` — added CI and license badges, added Contributing section

Closes #61

## Test plan

- [ ] All markdown passes markdownlint
- [ ] PR template renders correctly on new PRs
- [ ] CODEOWNERS auto-assigns reviewer
- [ ] README badges render on GitHub

Co-Authored-By: Claude <noreply@anthropic.com>