### PR TITLE
chore: split CI into lint, typecheck, and build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,46 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - run: npm ci
+      - run: npm run lint
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - run: npm ci
+      - run: npm run typecheck
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
     defaults:
       run:
         working-directory: ui


### PR DESCRIPTION
## Summary

Split the single CI build job into three separate jobs for better feedback and branch protection integration.

**Jobs:**
- **Lint** — runs `npm run lint` (ESLint)
- **Type Check** — runs `npm run typecheck` (`tsc --noEmit`)
- **Build** — runs `npm run build` (depends on Lint and Type Check passing)

Lint and Type Check run in parallel. Build only starts after both pass. Job names become the status check contexts for branch protection (PR #4).

## Test plan

- [ ] All three jobs appear in the Actions tab
- [ ] Lint and Type Check run in parallel
- [ ] Build only starts after both pass
- [ ] CI badge in README still works

Co-Authored-By: Claude <noreply@anthropic.com>