### PR TITLE
docs: add CHANGELOG.md for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- User feedback and support links with diagnostic review (#65)
+- Community health files: CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, PR template, CODEOWNERS (#66)
+- ESLint with TypeScript and React plugins (#67)
+- Dependabot for npm and GitHub Actions dependencies (#69)
+
+### Changed
+
+- CI split into parallel Lint, Type Check, and Build jobs (#68)
+- Repo settings: squash-only merges, auto-delete branches, branch protection (#69)
+
+## [0.1.0] - 2026-02-28
+
+### Added
+
+- Create, edit, and delete Docker command scripts
+- Tag-based organization with nested category grouping
+- One-click execution with inline output display
+- Search, sort, and filter runbooks
+- Grid and list layout modes with compact density option
+- Collapsible cards with expand/collapse all
+- Tag autocomplete with chip input
+- Command validation with syntax highlighting
+- Import/export runbooks (JSON and legacy format)
+- Category management with color-coded badges
+- GitHub Actions CI pipeline
+- Version display in footer
+
+[Unreleased]: https://github.com/HerbHall/Runbooks/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/HerbHall/Runbooks/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for developmen
 
 Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a detailed history of changes.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary

- Create `CHANGELOG.md` using [Keep a Changelog](https://keepachangelog.com/) format
- Document v0.1.0 feature set aligned with the existing GitHub release
- Add Unreleased section for post-tag contributor configuration work (#65-#69)
- Add Changelog section to README.md

Closes #55

## Test plan

- [ ] CHANGELOG.md follows Keep a Changelog 1.1.0 format
- [ ] v0.1.0 entry matches GitHub release feature list
- [ ] Comparison links resolve correctly on GitHub
- [ ] markdownlint passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)