### PR TITLE
feat: add React Error Boundary component

### DIFF
--- a/ui/src/components/ErrorBoundary.tsx
+++ b/ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,99 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+import { Box, Typography, Button, Paper } from "@mui/material";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("Uncaught error:", error, errorInfo);
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: "100vh",
+            p: 3,
+          }}
+        >
+          <Paper
+            elevation={3}
+            sx={{
+              p: 4,
+              maxWidth: 480,
+              width: "100%",
+              textAlign: "center",
+            }}
+          >
+            <ErrorOutlineIcon
+              sx={{ fontSize: 64, color: "error.main", mb: 2 }}
+            />
+            <Typography variant="h6" gutterBottom>
+              Something went wrong
+            </Typography>
+            <Box
+              component="pre"
+              sx={{
+                textAlign: "left",
+                bgcolor: "action.hover",
+                borderRadius: 1,
+                p: 1.5,
+                mt: 0,
+                mb: 3,
+                fontSize: "0.8rem",
+                lineHeight: 1.5,
+                maxHeight: 200,
+                overflowY: "auto",
+                overflowX: "auto",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+              }}
+            >
+              {this.state.error?.message ?? "An unexpected error occurred."}
+            </Box>
+            <Box sx={{ display: "flex", gap: 2, justifyContent: "center" }}>
+              <Button variant="contained" onClick={this.handleReset}>
+                Try Again
+              </Button>
+              <Button
+                variant="outlined"
+                href="https://github.com/HerbHall/Runbooks/issues/new?template=bug_report.yml"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Report Bug
+              </Button>
+            </Box>
+          </Paper>
+        </Box>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -5,6 +5,7 @@ import CssBaseline from "@mui/material/CssBaseline";
 import { RunbookProvider } from "./context/RunbookContext";
 import { CategoryProvider } from "./context/CategoryContext";
 import App from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
@@ -14,11 +15,13 @@ root.render(
   <React.StrictMode>
     <DockerMuiThemeProvider>
       <CssBaseline />
-      <RunbookProvider>
-        <CategoryProvider>
-          <App />
-        </CategoryProvider>
-      </RunbookProvider>
+      <ErrorBoundary>
+        <RunbookProvider>
+          <CategoryProvider>
+            <App />
+          </CategoryProvider>
+        </RunbookProvider>
+      </ErrorBoundary>
     </DockerMuiThemeProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary

- Add `ErrorBoundary` class component with themed MUI fallback UI
- Wrap app inside `DockerMuiThemeProvider` but outside context providers
- Fallback shows error details, Try Again button, and Report Bug link

Closes #58

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Lint and typecheck pass
- [ ] Intentional error (e.g., throw in a component) shows fallback UI
- [ ] Try Again button recovers the app
- [ ] Report Bug link opens GitHub issue template

🤖 Generated with [Claude Code](https://claude.com/claude-code)