### PR TITLE
chore: populate Dockerfile extension labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,11 @@ LABEL org.opencontainers.image.title="Runbooks" \
     org.opencontainers.image.licenses="MIT" \
     com.docker.desktop.extension.api.version="0.3.4" \
     com.docker.desktop.extension.icon="https://raw.githubusercontent.com/HerbHall/Runbooks/main/docker.svg" \
-    com.docker.extension.screenshots="" \
+    com.docker.extension.screenshots="[{\"alt\":\"Grid view with sample runbooks\",\"url\":\"https://raw.githubusercontent.com/HerbHall/Runbooks/main/docs/screenshots/grid-view.png\"},{\"alt\":\"Expanded cards showing command details\",\"url\":\"https://raw.githubusercontent.com/HerbHall/Runbooks/main/docs/screenshots/expanded-cards.png\"},{\"alt\":\"Search filtering runbooks\",\"url\":\"https://raw.githubusercontent.com/HerbHall/Runbooks/main/docs/screenshots/search-filter.png\"}]" \
     com.docker.extension.detailed-description="Create, organize, and execute saved Docker command scripts directly from Docker Desktop." \
     com.docker.extension.publisher-url="https://github.com/HerbHall" \
-    com.docker.extension.changelog=""
+    com.docker.extension.additional-urls="[{\"title\":\"Documentation\",\"url\":\"https://github.com/HerbHall/Runbooks#readme\"},{\"title\":\"Report a Bug\",\"url\":\"https://github.com/HerbHall/Runbooks/issues/new?template=bug_report.yml\"},{\"title\":\"Support\",\"url\":\"https://github.com/HerbHall/Runbooks/discussions\"}]" \
+    com.docker.extension.changelog="<ul><li>Create, edit, and execute Docker command scripts</li><li>Tag-based organization with nested grouping</li><li>Search, sort, and filter</li><li>Grid and list layouts with compact density</li><li>Command validation with syntax highlighting</li><li>Import/export runbooks</li></ul>"
 
 COPY metadata.json .
 COPY docker.svg .


### PR DESCRIPTION
## Summary

- Populate `com.docker.extension.screenshots` with 3 screenshot URLs
- Populate `com.docker.extension.changelog` with v0.1.0 HTML summary
- Add `com.docker.extension.additional-urls` with docs, bugs, and support links

Closes #56

## Test plan

- [ ] `docker build` succeeds with populated labels
- [ ] `docker inspect` shows correct label values
- [ ] Screenshot URLs resolve to actual images on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)