### PR TITLE
feat: add confirmation dialog for destructive commands

### DIFF
--- a/ui/src/components/RunbookExecutionDialog.tsx
+++ b/ui/src/components/RunbookExecutionDialog.tsx
@@ -9,9 +9,14 @@ import {
   Stack,
   Box,
   CircularProgress,
+  List,
+  ListItem,
+  ListItemText,
 } from "@mui/material";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import type { Runbook, CommandResult, ExecutionStatus } from "../types";
 import { useDockerDesktopClient } from "../App";
+import { getDestructiveWarnings, type DestructiveWarning } from "../utils/destructive-commands";
 
 interface RunbookExecutionDialogProps {
   open: boolean;
@@ -32,6 +37,8 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
   const [status, setStatus] = useState<ExecutionStatus>("idle");
   const [results, setResults] = useState<CommandResult[]>([]);
   const [currentIndex, setCurrentIndex] = useState(-1);
+  const [needsConfirmation, setNeedsConfirmation] = useState(false);
+  const [warnings, setWarnings] = useState<DestructiveWarning[]>([]);
   const abortRef = useRef(false);
 
   const execute = useCallback(async () => {
@@ -91,7 +98,13 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
 
   useEffect(() => {
     if (open) {
-      execute();
+      const detected = getDestructiveWarnings(runbook.commands);
+      if (detected.length > 0) {
+        setWarnings(detected);
+        setNeedsConfirmation(true);
+      } else {
+        execute();
+      }
     }
     return () => {
       abortRef.current = true;
@@ -105,8 +118,56 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
     setStatus("idle");
     setResults([]);
     setCurrentIndex(-1);
+    setNeedsConfirmation(false);
+    setWarnings([]);
     onClose();
   };
+
+  const handleConfirm = () => {
+    setNeedsConfirmation(false);
+    execute();
+  };
+
+  if (needsConfirmation) {
+    return (
+      <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
+        <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <WarningAmberIcon color="warning" />
+          Destructive Commands Detected
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            The following commands in <strong>{runbook.name}</strong> may delete data or remove
+            Docker resources:
+          </Typography>
+          <List dense disablePadding>
+            {warnings.map((w, i) => (
+              <ListItem key={i} disableGutters sx={{ alignItems: "flex-start" }}>
+                <ListItemText
+                  primary={
+                    <Typography
+                      component="span"
+                      variant="body2"
+                      sx={{ fontFamily: "monospace", fontWeight: 600 }}
+                    >
+                      $ {w.command}
+                    </Typography>
+                  }
+                  secondary={w.description}
+                />
+              </ListItem>
+            ))}
+          </List>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleConfirm} color="error" variant="contained">
+            Execute Anyway
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
 
   return (
     <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">

--- a/ui/src/utils/destructive-commands.ts
+++ b/ui/src/utils/destructive-commands.ts
@@ -1,0 +1,73 @@
+export interface DestructiveWarning {
+  command: string;
+  description: string;
+}
+
+interface DestructivePattern {
+  pattern: RegExp;
+  description: string;
+}
+
+const DESTRUCTIVE_PATTERNS: DestructivePattern[] = [
+  {
+    pattern: /^docker\s+system\s+prune\b/i,
+    description: "Removes all unused data (containers, networks, images, build cache)",
+  },
+  {
+    pattern: /^docker\s+container\s+prune\b/i,
+    description: "Removes all stopped containers",
+  },
+  {
+    pattern: /^docker\s+image\s+prune\b/i,
+    description: "Removes unused images",
+  },
+  {
+    pattern: /^docker\s+volume\s+prune\b/i,
+    description: "Removes all unused volumes (data loss risk)",
+  },
+  {
+    pattern: /^docker\s+network\s+prune\b/i,
+    description: "Removes all unused networks",
+  },
+  {
+    pattern: /^docker\s+builder\s+prune\b/i,
+    description: "Removes build cache",
+  },
+  {
+    pattern: /^docker\s+(?:container\s+)?(?:rm|remove)\b/i,
+    description: "Removes containers",
+  },
+  {
+    pattern: /^docker\s+(?:rmi|image\s+(?:rm|remove))\b/i,
+    description: "Removes images",
+  },
+  {
+    pattern: /^docker\s+volume\s+(?:rm|remove)\b/i,
+    description: "Removes volumes (data loss risk)",
+  },
+  {
+    pattern: /^docker\s+network\s+(?:rm|remove)\b/i,
+    description: "Removes networks",
+  },
+];
+
+export function getDestructiveWarnings(commands: string[]): DestructiveWarning[] {
+  const seen = new Set<string>();
+  const warnings: DestructiveWarning[] = [];
+
+  for (const command of commands) {
+    const trimmed = command.trim();
+    for (const { pattern, description } of DESTRUCTIVE_PATTERNS) {
+      if (pattern.test(trimmed)) {
+        const key = `${trimmed}::${description}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          warnings.push({ command: trimmed, description });
+        }
+        break;
+      }
+    }
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
## Summary

- Add `destructive-commands.ts` utility to detect dangerous Docker commands (prune, rm, rmi, volume rm, etc.)
- Show warning dialog with matched commands before execution
- Non-destructive commands execute immediately (zero UX change)
- Red "Execute Anyway" button for explicit confirmation

Closes #59

## Test plan

- [ ] Build, lint, and typecheck pass
- [ ] Running a non-destructive runbook executes immediately (no change)
- [ ] Running a destructive runbook (e.g., "Quick Cleanup") shows warning dialog
- [ ] Cancel button closes without executing
- [ ] "Execute Anyway" proceeds with execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)