### PR TITLE
chore: update README and CHANGELOG for Docker Hub publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- React Error Boundary with themed fallback UI and recovery (#58)
+- Confirmation dialog for destructive Docker commands (#59)
+- Unit test suite with Vitest -- 44 tests across 3 files (#60)
+- Test job in CI pipeline (#60)
 - User feedback and support links with diagnostic review (#65)
 - Community health files: CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, PR template, CODEOWNERS (#66)
 - ESLint with TypeScript and React plugins (#67)
 - Dependabot for npm and GitHub Actions dependencies (#69)
+- Dockerfile extension labels: screenshots, changelog, additional URLs (#56)
+- Published multi-arch image to Docker Hub (#57)
 
 ### Changed
 
-- CI split into parallel Lint, Type Check, and Build jobs (#68)
+- CI split into parallel Lint, Type Check, Test, and Build jobs (#68, #60)
 - Repo settings: squash-only merges, auto-delete branches, branch protection (#69)
 
 ## [0.1.0] - 2026-02-28

--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ A Docker Desktop Extension that lets you create, organize, and execute Docker co
 
 ## Installation
 
-> **Status:** v0.1.0 — builds locally. Not yet published to Docker Hub.
+```bash
+docker extension install herbhall/runbooks
+```
+
+Or build from source:
 
 ```bash
-# Build locally
 make build-extension
-
-# Install into Docker Desktop
 make install-extension
 ```
 


### PR DESCRIPTION
## Summary

- Replace "Not yet published to Docker Hub" with `docker extension install herbhall/runbooks`
- Update CHANGELOG Unreleased section with all Phase 2-3 deliverables (#56-#60)

Closes #57

## Manual step after merge

```bash
make push-extension TAG=0.1.0
make push-extension TAG=latest
```

## Test plan

- [ ] README install instructions are accurate
- [ ] CHANGELOG reflects all merged work
- [ ] markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)