### PR TITLE
chore: add release workflow for Docker Hub publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag (e.g. 0.1.0). Defaults to git tag or 'latest'."
+        required: false
+        type: string
+
+jobs:
+  publish:
+    name: Publish to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Determine version tag
+        id: version
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          elif [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.version.outputs.tag }}
+          tags: |
+            herbhall/runbooks:${{ steps.version.outputs.tag }}
+            herbhall/runbooks:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot for npm and GitHub Actions dependencies (#69)
 - Dockerfile extension labels: screenshots, changelog, additional URLs (#56)
 - Published multi-arch image to Docker Hub (#57)
+- GitHub Actions release workflow for automated Docker Hub publishing (#83)
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` for automated Docker Hub image publishing
- Triggers on tag push (`v*`) or manual `workflow_dispatch` with optional tag input
- Builds multi-arch (linux/amd64, linux/arm64) via Docker buildx
- Pushes both versioned tag and `latest` to `herbhall/runbooks`
- Requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets

## Test plan

- [ ] Verify workflow YAML is valid (CI lint passes)
- [ ] After merging, add Docker Hub secrets to repo settings
- [ ] Test manual dispatch from Actions tab
- [ ] Test tag-triggered publish: `git tag v0.1.1 && git push origin v0.1.1`

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)