### PR TITLE
feat: add parameterized commands with variable substitution

### DIFF
--- a/ui/src/components/CommandEditor.tsx
+++ b/ui/src/components/CommandEditor.tsx
@@ -1,10 +1,7 @@
 import Editor from "react-simple-code-editor";
 import { Box, FormHelperText, useTheme } from "@mui/material";
 import { ALL_COMMANDS, MANAGEMENT_COMMANDS, DOCKER_COMMANDS } from "../docker-commands";
-
-function escapeHtml(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
+import { VARIABLE_REGEX, escapeHtml } from "../utils/variables";
 
 /** Regex-based Docker CLI syntax highlighter */
 function highlightDocker(code: string): string {
@@ -70,7 +67,11 @@ function highlightDocker(code: string): string {
       result += remaining;
       return result;
     })
-    .join("\n");
+    .join("\n")
+    .replace(
+      new RegExp(VARIABLE_REGEX.source, "g"),
+      (m) => `<span style="color:var(--docker-variable)">${m}</span>`,
+    );
 }
 
 interface CommandEditorProps {
@@ -89,6 +90,7 @@ export function CommandEditor({ value, onChange }: CommandEditorProps) {
     "--docker-string": isDark ? "#a5d6ff" : "#0a3069",
     "--docker-comment": isDark ? "#8b949e" : "#6e7781",
     "--docker-unknown": isDark ? "#f85149" : "#cf222e",
+    "--docker-variable": isDark ? "#ffa657" : "#cf6b00",
   } as React.CSSProperties;
 
   return (
@@ -124,7 +126,7 @@ export function CommandEditor({ value, onChange }: CommandEditorProps) {
         />
       </Box>
       <FormHelperText>
-        Paste Docker commands directly — &quot;docker&quot; prefix is optional
+        &quot;docker&quot; prefix is optional. Use {"{{name}}"} for variables.
       </FormHelperText>
     </Box>
   );

--- a/ui/src/components/ParameterInputDialog.tsx
+++ b/ui/src/components/ParameterInputDialog.tsx
@@ -1,0 +1,153 @@
+import { useState, useMemo, useCallback } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  MenuItem,
+  Stack,
+  Box,
+  Typography,
+} from "@mui/material";
+import type { Runbook } from "../types";
+import { parseVariables, substituteVariables } from "../utils/variables";
+
+interface ParameterInputDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onRun: (resolvedCommands: string[]) => void;
+  runbook: Runbook;
+}
+
+export function ParameterInputDialog({ open, onClose, onRun, runbook }: ParameterInputDialogProps) {
+  const variables = useMemo(() => parseVariables(runbook.commands), [runbook.commands]);
+
+  const [values, setValues] = useState<Record<string, string>>(() => {
+    const init: Record<string, string> = {};
+    for (const v of parseVariables(runbook.commands)) {
+      init[v.name] = v.defaultValue;
+    }
+    return init;
+  });
+
+  // Re-initialize values when dialog opens with different runbook
+  const [lastRunbookId, setLastRunbookId] = useState(runbook.id);
+  if (runbook.id !== lastRunbookId) {
+    setLastRunbookId(runbook.id);
+    const init: Record<string, string> = {};
+    for (const v of variables) {
+      init[v.name] = v.defaultValue;
+    }
+    setValues(init);
+  }
+
+  const preview = useMemo(
+    () => substituteVariables(runbook.commands, values),
+    [runbook.commands, values],
+  );
+
+  const handleChange = useCallback((name: string, value: string) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+  }, []);
+
+  const handleRun = () => {
+    onRun(preview);
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(preview.join("\n"));
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>Parameters: {runbook.name}</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", gap: 2, mt: 1, minHeight: 200 }}>
+          {/* Left panel: live preview */}
+          <Box sx={{ flex: 3, minWidth: 0 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+              Preview
+            </Typography>
+            <Box
+              component="pre"
+              sx={{
+                bgcolor: "action.hover",
+                p: 1.5,
+                borderRadius: 1,
+                fontSize: "0.85rem",
+                lineHeight: 1.6,
+                overflow: "auto",
+                maxHeight: 300,
+                m: 0,
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-all",
+              }}
+            >
+              {preview.map((cmd, i) => (
+                <div key={i}>
+                  <Typography
+                    component="span"
+                    sx={{ color: "text.secondary", fontSize: "0.85rem", fontFamily: "inherit" }}
+                  >
+                    ${" "}
+                  </Typography>
+                  {cmd}
+                </div>
+              ))}
+            </Box>
+          </Box>
+
+          {/* Right panel: input form */}
+          <Box sx={{ flex: 2, minWidth: 200 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+              Variables
+            </Typography>
+            <Stack spacing={2}>
+              {variables.map((v) =>
+                v.options.length > 0 ? (
+                  <TextField
+                    key={v.name}
+                    select
+                    label={v.name}
+                    value={values[v.name] ?? ""}
+                    onChange={(e) => handleChange(v.name, e.target.value)}
+                    size="small"
+                    fullWidth
+                  >
+                    {v.options.map((opt) => (
+                      <MenuItem key={opt} value={opt}>
+                        {opt}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                ) : (
+                  <TextField
+                    key={v.name}
+                    label={v.name}
+                    value={values[v.name] ?? ""}
+                    onChange={(e) => handleChange(v.name, e.target.value)}
+                    size="small"
+                    fullWidth
+                    placeholder={v.defaultValue || undefined}
+                  />
+                ),
+              )}
+            </Stack>
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCopy} size="small">
+          Copy
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" onClick={handleRun}>
+          Run
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/ui/src/components/RunbookCard.tsx
+++ b/ui/src/components/RunbookCard.tsx
@@ -15,6 +15,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import type { Runbook, Category } from "../types";
+import { VARIABLE_REGEX, escapeHtml } from "../utils/variables";
 import { RunbookFormDialog } from "./RunbookFormDialog";
 import { RunbookDeleteDialog } from "./RunbookDeleteDialog";
 import { RunbookExecutionDialog } from "./RunbookExecutionDialog";
@@ -86,7 +87,14 @@ export function RunbookCard({ runbook, category, collapsed = false, onToggleColl
                   m: 0,
                 }}
               >
-                {runbook.commands.join("\n")}
+                <code
+                  dangerouslySetInnerHTML={{
+                    __html: escapeHtml(runbook.commands.join("\n")).replace(
+                      new RegExp(VARIABLE_REGEX.source, "g"),
+                      (m) => `<span style="color:#cf6b00">${m}</span>`,
+                    ),
+                  }}
+                />
               </Box>
             </>
           </Collapse>

--- a/ui/src/components/RunbookExecutionDialog.tsx
+++ b/ui/src/components/RunbookExecutionDialog.tsx
@@ -17,6 +17,8 @@ import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import type { Runbook, CommandResult, ExecutionStatus } from "../types";
 import { useDockerDesktopClient } from "../App";
 import { getDestructiveWarnings, type DestructiveWarning } from "../utils/destructive-commands";
+import { hasVariables } from "../utils/variables";
+import { ParameterInputDialog } from "./ParameterInputDialog";
 
 interface RunbookExecutionDialogProps {
   open: boolean;
@@ -39,9 +41,12 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
   const [currentIndex, setCurrentIndex] = useState(-1);
   const [needsConfirmation, setNeedsConfirmation] = useState(false);
   const [warnings, setWarnings] = useState<DestructiveWarning[]>([]);
+  const [needsParameters, setNeedsParameters] = useState(false);
+  const [resolvedCommands, setResolvedCommands] = useState<string[] | null>(null);
   const abortRef = useRef(false);
 
-  const execute = useCallback(async () => {
+  const execute = useCallback(async (cmds?: string[]) => {
+    const commands = cmds ?? resolvedCommands ?? runbook.commands;
     abortRef.current = false;
     setStatus("running");
     setResults([]);
@@ -49,11 +54,11 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
 
     const collected: CommandResult[] = [];
 
-    for (let i = 0; i < runbook.commands.length; i++) {
+    for (let i = 0; i < commands.length; i++) {
       if (abortRef.current) break;
       setCurrentIndex(i);
 
-      const raw = runbook.commands[i].trim();
+      const raw = commands[i].trim();
       const tokens = parseCommand(raw);
       const start = performance.now();
 
@@ -94,16 +99,20 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
       ddClient.desktopUI.toast.success(`Runbook completed: ${runbook.name}`);
     }
     setCurrentIndex(-1);
-  }, [ddClient, runbook]);
+  }, [ddClient, runbook, resolvedCommands]);
 
   useEffect(() => {
     if (open) {
-      const detected = getDestructiveWarnings(runbook.commands);
-      if (detected.length > 0) {
-        setWarnings(detected);
-        setNeedsConfirmation(true);
+      if (hasVariables(runbook.commands)) {
+        setNeedsParameters(true);
       } else {
-        execute();
+        const detected = getDestructiveWarnings(runbook.commands);
+        if (detected.length > 0) {
+          setWarnings(detected);
+          setNeedsConfirmation(true);
+        } else {
+          execute();
+        }
       }
     }
     return () => {
@@ -119,6 +128,8 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
     setResults([]);
     setCurrentIndex(-1);
     setNeedsConfirmation(false);
+    setNeedsParameters(false);
+    setResolvedCommands(null);
     setWarnings([]);
     onClose();
   };
@@ -127,6 +138,29 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
     setNeedsConfirmation(false);
     execute();
   };
+
+  const handleParameterSubmit = (resolved: string[]) => {
+    setNeedsParameters(false);
+    setResolvedCommands(resolved);
+    const detected = getDestructiveWarnings(resolved);
+    if (detected.length > 0) {
+      setWarnings(detected);
+      setNeedsConfirmation(true);
+    } else {
+      execute(resolved);
+    }
+  };
+
+  if (needsParameters) {
+    return (
+      <ParameterInputDialog
+        open={open}
+        onClose={handleClose}
+        onRun={handleParameterSubmit}
+        runbook={runbook}
+      />
+    );
+  }
 
   if (needsConfirmation) {
     return (
@@ -177,7 +211,7 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
       </DialogTitle>
       <DialogContent>
         <Stack spacing={2}>
-          {runbook.commands.map((cmd, i) => (
+          {(resolvedCommands ?? runbook.commands).map((cmd, i) => (
             <Box key={i}>
               <Typography variant="subtitle2" sx={{ fontFamily: "monospace" }}>
                 $ {cmd}

--- a/ui/src/components/RunbookFormDialog.tsx
+++ b/ui/src/components/RunbookFormDialog.tsx
@@ -28,6 +28,7 @@ import {
   MANAGEMENT_COMMANDS,
   findClosest,
 } from "../docker-commands";
+import { parseVariables } from "../utils/variables";
 
 const COMMON_TAGS = ["info", "cleanup", "dev", "production", "maintenance", "monitoring", "caution"];
 
@@ -98,6 +99,10 @@ export function RunbookFormDialog({ open, onClose, runbook }: RunbookFormDialogP
   const [categoryId, setCategoryId] = useState("");
 
   const commandWarnings = useMemo(() => validateCommands(commands), [commands]);
+  const variableCount = useMemo(
+    () => parseVariables(commands.split("\n").map((c) => c.trim()).filter(Boolean)).length,
+    [commands],
+  );
 
   const allTags = useMemo(() => {
     const tagSet = new Set(COMMON_TAGS);
@@ -199,6 +204,12 @@ export function RunbookFormDialog({ open, onClose, runbook }: RunbookFormDialogP
               Paste commands directly from terminals or docs. The &quot;docker&quot; prefix is optional.
             </Typography>
           </div>
+          {variableCount > 0 && (
+            <Alert severity="info" sx={{ py: 0, "& .MuiAlert-message": { fontSize: "0.8rem" } }}>
+              {variableCount} variable{variableCount > 1 ? "s" : ""} detected — values will be
+              prompted before execution.
+            </Alert>
+          )}
           {commandWarnings.length > 0 && (
             <Alert severity="warning" sx={{ py: 0, "& .MuiAlert-message": { fontSize: "0.8rem" } }}>
               {commandWarnings.map((w) => (

--- a/ui/src/storage.ts
+++ b/ui/src/storage.ts
@@ -65,6 +65,15 @@ export const DEFAULT_RUNBOOKS: Runbook[] = [
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
   },
+  {
+    id: "example-7",
+    name: "Container Logs",
+    description: "View recent logs for a specific container",
+    commands: ["docker logs --tail {{lines=100}} {{container}}"],
+    tags: ["info"],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
 ];
 
 export function loadRunbooks(): Runbook[] {

--- a/ui/src/utils/variables.test.ts
+++ b/ui/src/utils/variables.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseVariables,
+  hasVariables,
+  substituteVariables,
+  escapeHtml,
+} from "./variables";
+
+describe("parseVariables", () => {
+  it("parses a simple variable with no default", () => {
+    const vars = parseVariables(["docker exec -it {{container}} bash"]);
+    expect(vars).toHaveLength(1);
+    expect(vars[0].name).toBe("container");
+    expect(vars[0].defaultValue).toBe("");
+    expect(vars[0].options).toEqual([]);
+  });
+
+  it("parses a variable with default value", () => {
+    const vars = parseVariables(["docker logs --tail {{lines=100}} app"]);
+    expect(vars).toHaveLength(1);
+    expect(vars[0].name).toBe("lines");
+    expect(vars[0].defaultValue).toBe("100");
+  });
+
+  it("parses a variable with options", () => {
+    const vars = parseVariables([
+      "docker run --restart {{policy|no,always,unless-stopped}} app",
+    ]);
+    expect(vars).toHaveLength(1);
+    expect(vars[0].name).toBe("policy");
+    expect(vars[0].options).toEqual(["no", "always", "unless-stopped"]);
+    expect(vars[0].defaultValue).toBe("");
+  });
+
+  it("parses a variable with default and options", () => {
+    const vars = parseVariables([
+      "docker run --restart {{policy=always|no,always,unless-stopped}} app",
+    ]);
+    expect(vars).toHaveLength(1);
+    expect(vars[0].name).toBe("policy");
+    expect(vars[0].defaultValue).toBe("always");
+    expect(vars[0].options).toEqual(["no", "always", "unless-stopped"]);
+  });
+
+  it("deduplicates by name, first occurrence wins", () => {
+    const vars = parseVariables([
+      "curl {{host=localhost}}:{{port}} && curl {{host}}:{{port=8080}}",
+    ]);
+    expect(vars).toHaveLength(2);
+    expect(vars[0].name).toBe("host");
+    expect(vars[0].defaultValue).toBe("localhost");
+    expect(vars[1].name).toBe("port");
+    expect(vars[1].defaultValue).toBe("");
+  });
+
+  it("skips Go template expressions with dot prefix", () => {
+    const vars = parseVariables([
+      'docker ps --format "table {{.Names}}\\t{{.Status}}"',
+    ]);
+    expect(vars).toHaveLength(0);
+  });
+
+  it("skips escaped variables", () => {
+    const vars = parseVariables(["echo \\{{literal}} and {{real}}"]);
+    expect(vars).toHaveLength(1);
+    expect(vars[0].name).toBe("real");
+  });
+
+  it("parses variables across multiple commands", () => {
+    const vars = parseVariables([
+      "docker pull {{image}}",
+      "docker run -d --name {{name}} {{image}}",
+    ]);
+    expect(vars).toHaveLength(2);
+    expect(vars[0].name).toBe("image");
+    expect(vars[1].name).toBe("name");
+  });
+
+  it("handles mixed Go templates and variables", () => {
+    const vars = parseVariables([
+      'docker logs --tail {{lines=50}} $(docker ps -q --filter "name={{.Names}}")',
+    ]);
+    expect(vars).toHaveLength(1);
+    expect(vars[0].name).toBe("lines");
+  });
+
+  it("returns empty array for no variables", () => {
+    expect(parseVariables(["docker ps"])).toEqual([]);
+    expect(parseVariables([])).toEqual([]);
+  });
+
+  it("handles variable names with underscores", () => {
+    const vars = parseVariables(["docker run {{my_container_name}}"]);
+    expect(vars).toHaveLength(1);
+    expect(vars[0].name).toBe("my_container_name");
+  });
+
+  it("handles multiple variables on one line", () => {
+    const vars = parseVariables([
+      "docker run -p {{host_port}}:{{container_port}} {{image}}",
+    ]);
+    expect(vars).toHaveLength(3);
+    expect(vars.map((v) => v.name)).toEqual([
+      "host_port",
+      "container_port",
+      "image",
+    ]);
+  });
+
+  it("trims whitespace from option values", () => {
+    const vars = parseVariables(["{{env| dev , staging , prod }}"]);
+    expect(vars[0].options).toEqual(["dev", "staging", "prod"]);
+  });
+
+  it("preserves fullMatch string", () => {
+    const vars = parseVariables(["{{name=default|a,b}}"]);
+    expect(vars[0].fullMatch).toBe("{{name=default|a,b}}");
+  });
+});
+
+describe("hasVariables", () => {
+  it("returns true for commands with variables", () => {
+    expect(hasVariables(["docker exec -it {{container}} bash"])).toBe(true);
+  });
+
+  it("returns false for plain commands", () => {
+    expect(hasVariables(["docker ps"])).toBe(false);
+    expect(hasVariables([])).toBe(false);
+  });
+
+  it("returns false for Go template expressions", () => {
+    expect(
+      hasVariables([
+        'docker ps --format "table {{.Names}}\\t{{.Status}}"',
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns false for escaped variables", () => {
+    expect(hasVariables(["echo \\{{literal}}"])).toBe(false);
+  });
+
+  it("returns true when mixed with Go templates", () => {
+    expect(
+      hasVariables(["docker logs --tail {{lines}} {{.Names}}"]),
+    ).toBe(true);
+  });
+});
+
+describe("substituteVariables", () => {
+  it("substitutes a simple variable", () => {
+    const result = substituteVariables(
+      ["docker exec -it {{container}} bash"],
+      { container: "my-app" },
+    );
+    expect(result).toEqual(["docker exec -it my-app bash"]);
+  });
+
+  it("substitutes multiple occurrences of the same variable", () => {
+    const result = substituteVariables(
+      ["echo {{host}} && ping {{host}}"],
+      { host: "localhost" },
+    );
+    expect(result).toEqual(["echo localhost && ping localhost"]);
+  });
+
+  it("falls back to default value when no value provided", () => {
+    const result = substituteVariables(
+      ["docker logs --tail {{lines=100}} app"],
+      {},
+    );
+    expect(result).toEqual(["docker logs --tail 100 app"]);
+  });
+
+  it("uses provided value over default", () => {
+    const result = substituteVariables(
+      ["docker logs --tail {{lines=100}} app"],
+      { lines: "50" },
+    );
+    expect(result).toEqual(["docker logs --tail 50 app"]);
+  });
+
+  it("replaces with empty string when no value and no default", () => {
+    const result = substituteVariables(["docker exec {{container}}"], {});
+    expect(result).toEqual(["docker exec "]);
+  });
+
+  it("unescapes \\{{ to {{", () => {
+    const result = substituteVariables(
+      ["echo \\{{literal}} and {{name}}"],
+      { name: "test" },
+    );
+    expect(result).toEqual(["echo {{literal}} and test"]);
+  });
+
+  it("leaves Go template {{.Field}} untouched", () => {
+    const result = substituteVariables(
+      ['docker ps --format "{{.Names}}"'],
+      {},
+    );
+    expect(result).toEqual(['docker ps --format "{{.Names}}"']);
+  });
+
+  it("handles variables with options", () => {
+    const result = substituteVariables(
+      ["docker run --restart {{policy|no,always}} app"],
+      { policy: "always" },
+    );
+    expect(result).toEqual(["docker run --restart always app"]);
+  });
+
+  it("substitutes across multiple commands", () => {
+    const result = substituteVariables(
+      ["docker pull {{image}}", "docker run {{image}}"],
+      { image: "nginx:latest" },
+    );
+    expect(result).toEqual([
+      "docker pull nginx:latest",
+      "docker run nginx:latest",
+    ]);
+  });
+
+  it("handles empty value for variable with options (uses empty)", () => {
+    const result = substituteVariables(
+      ["docker run --restart {{policy=always|no,always}} app"],
+      { policy: "" },
+    );
+    expect(result).toEqual(["docker run --restart always app"]);
+  });
+});
+
+describe("escapeHtml", () => {
+  it("escapes ampersands", () => {
+    expect(escapeHtml("a & b")).toBe("a &amp; b");
+  });
+
+  it("escapes angle brackets", () => {
+    expect(escapeHtml("<div>")).toBe("&lt;div&gt;");
+  });
+
+  it("does not escape curly braces", () => {
+    expect(escapeHtml("{{name}}")).toBe("{{name}}");
+  });
+});

--- a/ui/src/utils/variables.ts
+++ b/ui/src/utils/variables.ts
@@ -1,0 +1,90 @@
+/** Parsed variable extracted from command text */
+export interface ParsedVariable {
+  name: string;
+  defaultValue: string;
+  options: string[];
+  fullMatch: string;
+}
+
+/**
+ * Regex for matching Runbook variables in command text.
+ *
+ * Matches: {{name}}, {{name=default}}, {{name|a,b}}, {{name=default|a,b}}
+ * Skips:   {{.Names}} (Go template — dot prefix), \{{escaped}} (backslash escape)
+ *
+ * Capture groups:
+ *   1: variable name (required)
+ *   2: default value (optional, after =, before | if present)
+ *   3: options list (optional, after |, comma-separated)
+ */
+export const VARIABLE_REGEX =
+  /(?<!\\)\{\{([a-zA-Z_][a-zA-Z0-9_]*)(?:=([^|}]*))?(?:\|([^}]+))?\}\}/g;
+
+/** Non-global version for test/match use */
+const VARIABLE_REGEX_TEST =
+  /(?<!\\)\{\{([a-zA-Z_][a-zA-Z0-9_]*)(?:=([^|}]*))?(?:\|([^}]+))?\}\}/;
+
+/**
+ * Parse all unique variables from an array of command strings.
+ * Deduplicates by name — first occurrence wins for default/options.
+ */
+export function parseVariables(commands: string[]): ParsedVariable[] {
+  const seen = new Map<string, ParsedVariable>();
+
+  for (const cmd of commands) {
+    const regex = new RegExp(VARIABLE_REGEX.source, "g");
+    let match;
+    while ((match = regex.exec(cmd)) !== null) {
+      const name = match[1];
+      if (!seen.has(name)) {
+        seen.set(name, {
+          name,
+          defaultValue: match[2] ?? "",
+          options: match[3] ? match[3].split(",").map((o) => o.trim()) : [],
+          fullMatch: match[0],
+        });
+      }
+    }
+  }
+
+  return Array.from(seen.values());
+}
+
+/** Fast check: do any commands contain at least one variable? */
+export function hasVariables(commands: string[]): boolean {
+  return commands.some((cmd) => VARIABLE_REGEX_TEST.test(cmd));
+}
+
+/**
+ * Substitute variable values into command strings.
+ * - Replaces all {{name}}/{{name=default}}/{{name|opts}} with values[name]
+ * - Falls back to defaultValue if values[name] is undefined
+ * - Unescapes \{{ to {{ after substitution
+ * - Leaves Go template {{.Field}} untouched
+ */
+export function substituteVariables(
+  commands: string[],
+  values: Record<string, string>,
+): string[] {
+  return commands.map((cmd) => {
+    const substituted = cmd.replace(
+      new RegExp(VARIABLE_REGEX.source, "g"),
+      (_fullMatch, name: string, defaultValue?: string) => {
+        if (name in values && values[name] !== "") {
+          return values[name];
+        }
+        return defaultValue ?? "";
+      },
+    );
+    // Unescape \{{ to {{
+    return substituted.replace(/\\\{\{/g, "{{");
+  });
+}
+
+/** Escape HTML special characters for safe innerHTML rendering */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}


### PR DESCRIPTION
## Summary

- Add `{{name=default|opt1,opt2}}` variable syntax for reusable Docker commands
- Two-panel parameter input dialog with live command preview and input form
- Orange syntax highlighting for variables in the command editor and card previews
- Variable info alert in the create/edit form showing detected variable count
- Go template expressions (`{{.Names}}`) correctly ignored by the parser
- New "Container Logs" example runbook demonstrating `{{lines=100}}` and `{{container}}` variables
- 32 new unit tests for variable parsing, substitution, and edge cases (76 total)

Closes #86

## Test plan

- [ ] `cd ui && npx vitest run` — all 76 tests pass (32 new variable tests)
- [ ] `cd ui && npx tsc --noEmit` — TypeScript clean
- [ ] `cd ui && npx eslint src/` — no new warnings
- [ ] Create runbook with `docker logs --tail {{lines=100}} {{container}}` — verify orange highlighting in editor and card
- [ ] Click Run — verify two-panel dialog with `lines` pre-filled "100" and `container` empty
- [ ] Fill values — verify live preview updates
- [ ] Existing "Running Containers" runbook with `{{.Names}}` — verify NO parameter dialog (Go template ignored)
- [ ] Runbook with `{{env=prod|dev,staging,prod}}` — verify dropdown with 3 options, "prod" pre-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)