### PR TITLE
feat: copy-to-clipboard button + persist group collapse state

### DIFF
--- a/ui/src/components/RunbookCard.tsx
+++ b/ui/src/components/RunbookCard.tsx
@@ -11,6 +11,7 @@ import {
 } from "@mui/material";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import EditIcon from "@mui/icons-material/Edit";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
@@ -58,6 +59,13 @@ export function RunbookCard({ runbook, category, collapsed = false, onToggleColl
             <Box sx={{ flex: 1 }} />
             <IconButton size="small" color="primary" title="Run" onClick={() => setExecOpen(true)}>
               <PlayArrowIcon fontSize="small" />
+            </IconButton>
+            <IconButton
+              size="small"
+              title="Copy commands"
+              onClick={() => navigator.clipboard.writeText(runbook.commands.join("\n"))}
+            >
+              <ContentCopyIcon fontSize="small" />
             </IconButton>
             <IconButton size="small" title="Edit" onClick={() => setEditOpen(true)}>
               <EditIcon fontSize="small" />

--- a/ui/src/components/RunbookList.tsx
+++ b/ui/src/components/RunbookList.tsx
@@ -67,7 +67,9 @@ export function RunbookList() {
   const [compact, setCompact] = useState<boolean>(
     () => loadPreference<boolean>("compact", false),
   );
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [collapsed, setCollapsed] = useState<Set<string>>(
+    () => new Set(loadPreference<string[]>("collapsedGroups", [])),
+  );
   const [collapsedCards, setCollapsedCards] = useState<Set<string>>(new Set());
 
   const categoryMap = useMemo(
@@ -182,6 +184,7 @@ export function RunbookList() {
       const next = new Set(prev);
       if (next.has(key)) next.delete(key);
       else next.add(key);
+      savePreference("collapsedGroups", [...next]);
       return next;
     });
   };


### PR DESCRIPTION
## Summary

- Add copy button on each runbook card to copy commands to clipboard (#91)
- Persist group collapse state across page reloads via localStorage (#93)
- Close #98 (jsdom already in devDependencies)

Closes #91, Closes #93

## Test plan

- [ ] Click copy button on a card — verify commands copied to clipboard
- [ ] Collapse a group, reload page — verify group stays collapsed
- [ ] Expand it back, reload — verify it stays expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)