### PR TITLE
ci: add extension validation gate to CI and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,19 @@ on:
     branches: [main]
 
 jobs:
+  validate:
+    name: Validate Extension
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate extension packaging
+        run: bash scripts/validate-extension.sh
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -64,7 +77,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test]
+    needs: [validate, lint, typecheck, test]
     defaults:
       run:
         working-directory: ui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,23 @@ on:
         type: string
 
 jobs:
+  validate:
+    name: Validate Extension
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate extension packaging
+        run: bash scripts/validate-extension.sh
+
   publish:
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
+    needs: [validate]
     steps:
       - uses: actions/checkout@v6
 

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,11 @@ prepare-buildx: ## Create buildx builder for multi-arch build
 push-extension: prepare-buildx ## Build and push multi-arch extension image
 	docker buildx build --push --builder=$(BUILDER) --platform=linux/amd64,linux/arm64 --build-arg VERSION=$(VERSION) --tag=$(IMAGE):$(TAG) .
 
-validate-extension: ## Validate the extension
+validate-extension: ## Validate the extension (requires Docker Desktop)
 	docker extension validate $(IMAGE):$(TAG)
+
+validate: ## Static validation of Dockerfile labels and metadata.json
+	@bash scripts/validate-extension.sh
 
 dev-ui: ## Start UI hot reload for development
 	cd ui && npm run dev

--- a/scripts/validate-extension.sh
+++ b/scripts/validate-extension.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Static validation for Docker Desktop extension packaging.
+# Catches missing Dockerfile labels and metadata.json fields
+# before they reach Docker Hub and fail marketplace submission.
+#
+# Usage: bash scripts/validate-extension.sh [Dockerfile] [metadata.json]
+
+set -euo pipefail
+
+DOCKERFILE="${1:-Dockerfile}"
+METADATA="${2:-metadata.json}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Find python
+PYTHON=""
+for p in python3 python; do
+    if command -v "$p" &>/dev/null && "$p" --version &>/dev/null 2>&1; then
+        PYTHON="$p"
+        break
+    fi
+done
+
+if [ -z "$PYTHON" ]; then
+    echo "ERROR: python3 or python required for validation"
+    exit 2
+fi
+
+exec "$PYTHON" "$SCRIPT_DIR/validate_extension.py" "$DOCKERFILE" "$METADATA"

--- a/scripts/validate_extension.py
+++ b/scripts/validate_extension.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Static validation for Docker Desktop extension packaging.
+
+Checks Dockerfile labels and metadata.json fields without requiring
+Docker Desktop. Designed to run in CI (GitHub Actions ubuntu runner).
+"""
+
+import json
+import os
+import re
+import sys
+
+RED = "\033[0;31m"
+GREEN = "\033[0;32m"
+RESET = "\033[0m"
+
+errors = 0
+
+
+def fail(msg: str) -> None:
+    global errors
+    print(f"{RED}FAIL: {msg}{RESET}")
+    errors += 1
+
+
+def ok(msg: str) -> None:
+    print(f"{GREEN}OK: {msg}{RESET}")
+
+
+def info(msg: str) -> None:
+    print(f"  {msg}")
+
+
+# Required labels for Docker Marketplace submission
+REQUIRED_LABELS = [
+    "org.opencontainers.image.title",
+    "org.opencontainers.image.description",
+    "org.opencontainers.image.vendor",
+    "com.docker.desktop.extension.api.version",
+    "com.docker.desktop.extension.icon",
+    "com.docker.extension.screenshots",
+    "com.docker.extension.detailed-description",
+    "com.docker.extension.publisher-url",
+    "com.docker.extension.changelog",
+    "com.docker.extension.categories",
+]
+
+# Labels that must contain valid JSON arrays
+JSON_LABELS = [
+    "com.docker.extension.screenshots",
+    "com.docker.extension.additional-urls",
+]
+
+# Labels that are optional (don't fail if missing, but validate if present)
+OPTIONAL_LABELS = [
+    "com.docker.extension.additional-urls",
+]
+
+
+def extract_labels(content: str) -> dict[str, str]:
+    """Extract all LABEL key=value pairs from a Dockerfile.
+
+    Handles multi-line LABEL blocks with backslash continuation and
+    values containing escaped quotes.
+    """
+    labels = {}
+
+    # Collapse backslash-newline continuations
+    collapsed = content.replace("\\\n", " ")
+
+    # Find all label assignments: key="value" (with escaped quotes in value)
+    for match in re.finditer(
+        r'([a-zA-Z0-9._-]+)\s*=\s*"((?:[^"\\]|\\.)*)"', collapsed
+    ):
+        key = match.group(1)
+        raw_value = match.group(2)
+        # Unescape Dockerfile string escapes
+        value = raw_value.replace('\\"', '"')
+        labels[key] = value
+
+    return labels
+
+
+def validate_dockerfile(path: str) -> dict[str, str]:
+    """Validate Dockerfile labels. Returns extracted labels."""
+    print(f"--- Dockerfile labels ({path}) ---")
+
+    if not os.path.isfile(path):
+        fail(f"{path} not found")
+        return {}
+
+    with open(path) as f:
+        content = f.read()
+
+    labels = extract_labels(content)
+
+    # Check required labels
+    for label in REQUIRED_LABELS:
+        if label in labels and labels[label]:
+            ok(label)
+        else:
+            fail(f"missing required label: {label}")
+
+    return labels
+
+
+def validate_json_labels(labels: dict[str, str]) -> None:
+    """Validate that JSON-valued labels parse correctly."""
+    print()
+    print("--- JSON label validation ---")
+
+    for label in JSON_LABELS:
+        if label not in labels:
+            if label in OPTIONAL_LABELS:
+                info(f"SKIP: {label} (optional, not present)")
+            else:
+                fail(f"{label} value not found")
+            continue
+
+        value = labels[label]
+        try:
+            parsed = json.loads(value)
+            if not isinstance(parsed, list):
+                fail(f"{label} must be a JSON array, got {type(parsed).__name__}")
+            else:
+                ok(f"{label} is valid JSON ({len(parsed)} items)")
+        except json.JSONDecodeError as e:
+            fail(f"{label} is not valid JSON: {e}")
+
+
+def validate_metadata(path: str) -> None:
+    """Validate metadata.json required fields."""
+    print()
+    print(f"--- metadata.json ({path}) ---")
+
+    if not os.path.isfile(path):
+        fail(f"{path} not found")
+        return
+
+    with open(path) as f:
+        try:
+            meta = json.load(f)
+        except json.JSONDecodeError as e:
+            fail(f"invalid JSON: {e}")
+            return
+
+    ok("valid JSON")
+
+    # Check required fields
+    if not meta.get("icon"):
+        fail("missing required field: icon")
+    else:
+        ok(f"icon field present: {meta['icon']}")
+
+    # host.binaries is required by marketplace validator
+    host = meta.get("host")
+    if host is None:
+        fail("missing required section: host")
+    elif "binaries" not in host:
+        fail("missing required field: host.binaries")
+    else:
+        ok("host.binaries present")
+
+    # Check for obsolete fields
+    obsolete_found = False
+    for field in ["name", "provider"]:
+        if field in meta:
+            fail(f"obsolete field found: {field} (remove it)")
+            obsolete_found = True
+    if not obsolete_found:
+        ok("no obsolete fields")
+
+    # Cross-reference: icon file exists
+    icon = meta.get("icon", "")
+    if icon and os.path.isfile(icon):
+        ok(f"icon file '{icon}' exists")
+    elif icon:
+        fail(f"icon file '{icon}' referenced but not found")
+
+
+def validate_build_config(dockerfile_path: str) -> None:
+    """Check for multi-platform build support."""
+    print()
+    print("--- Build configuration ---")
+
+    with open(dockerfile_path) as f:
+        content = f.read()
+
+    if "BUILDPLATFORM" in content:
+        ok("multi-platform build support (BUILDPLATFORM arg found)")
+    else:
+        info("WARN: no BUILDPLATFORM arg -- may not support multi-arch builds")
+
+
+def main() -> int:
+    dockerfile = sys.argv[1] if len(sys.argv) > 1 else "Dockerfile"
+    metadata = sys.argv[2] if len(sys.argv) > 2 else "metadata.json"
+
+    print("==> Validating Docker Desktop extension packaging")
+    print()
+
+    labels = validate_dockerfile(dockerfile)
+    if labels:
+        validate_json_labels(labels)
+    validate_metadata(metadata)
+    if os.path.isfile(dockerfile):
+        validate_build_config(dockerfile)
+
+    print()
+    if errors == 0:
+        print(f"{GREEN}==> All checks passed{RESET}")
+        return 0
+    else:
+        print(f"{RED}==> {errors} error(s) found{RESET}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds static validation script (`scripts/validate_extension.py`) that checks all 10 required Dockerfile labels and metadata.json fields without requiring Docker Desktop
- Adds `Validate Extension` job to CI workflow (runs on every PR, parallel with lint/typecheck/test)
- Adds `Validate Extension` gate to Release workflow (must pass before Docker Hub push)
- Adds `make validate` target for local developer use

This would have caught both issues that broke the v0.1.1 marketplace submission:
1. Missing `com.docker.extension.categories` label
2. Missing `host.binaries` in metadata.json

## Test plan

- [x] `make validate` passes on current codebase (all checks green)
- [x] Removing `categories` label causes expected failure
- [x] Removing `host` section from metadata.json causes expected failure
- [ ] CI Validate job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)