### PR TITLE
chore: bump version to 0.2.0 across all files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-01
+
 ### Added
 
-- React Error Boundary with themed fallback UI and recovery (#58)
-- Confirmation dialog for destructive Docker commands (#59)
-- Unit test suite with Vitest -- 44 tests across 3 files (#60)
-- Test job in CI pipeline (#60)
+- Parameterized commands with `{{name=default|opts}}` variable substitution (#108)
+- Copy-to-clipboard button on runbook cards (#109)
+- Persist group collapse state across reloads (#109)
+- React Error Boundary with themed fallback UI and recovery (#78)
+- Confirmation dialog for destructive Docker commands (#80)
+- Unit test suite with Vitest -- 76 tests across 4 files (#81)
+- Test job in CI pipeline (#81)
 - User feedback and support links with diagnostic review (#65)
 - Community health files: CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, PR template, CODEOWNERS (#66)
 - ESLint with TypeScript and React plugins (#67)
 - Dependabot for npm and GitHub Actions dependencies (#69)
-- Dockerfile extension labels: screenshots, changelog, additional URLs (#56)
-- Published multi-arch image to Docker Hub (#57)
-- GitHub Actions release workflow for automated Docker Hub publishing (#83)
+- Dockerfile extension labels: screenshots, changelog, additional URLs (#79)
+- GitHub Actions release workflow for automated Docker Hub publishing (#84)
+- Static extension validation gate in CI and release (#110)
+- Extension categories label and host.binaries for marketplace validation (#85)
 
 ### Changed
 
-- CI split into parallel Lint, Type Check, Test, and Build jobs (#68, #60)
+- CI split into parallel Lint, Type Check, Test, and Build jobs (#68)
 - Repo settings: squash-only merges, auto-delete branches, branch protection (#69)
 
 ## [0.1.0] - 2026-02-28
@@ -43,5 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions CI pipeline
 - Version display in footer
 
-[Unreleased]: https://github.com/HerbHall/Runbooks/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/HerbHall/Runbooks/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/HerbHall/Runbooks/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/HerbHall/Runbooks/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 - **Repo:** https://github.com/HerbHall/Runbooks
 - **License:** MIT
 - **Owner:** Herb Hall (HerbHall)
-- **Status:** Feature-complete MVP (v0.1.0), untested in Docker Desktop
+- **Status:** Feature-complete MVP (v0.2.0), tested in Docker Desktop
 - **Workspace:** `D:\DevSpace\runbooks.code-workspace` (DevSpace root, per convention)
 
 ## Architecture

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm run build
 # Final extension image
 FROM alpine:3.19
 
-ARG VERSION=0.1.0
+ARG VERSION=0.2.0
 
 LABEL org.opencontainers.image.title="Runbooks" \
     org.opencontainers.image.description="Saved command scripts for Docker Desktop" \

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runbooks-ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary

- Fixes version mismatch: Docker image tag showed `0.1.1` but UI footer showed `v0.1.0`
- Bumps all version references to `0.2.0` (ui/package.json, Dockerfile, CHANGELOG, CLAUDE.md)
- CHANGELOG now documents all changes since v0.1.0 under a single `[0.2.0]` section
- `ui/package.json` is the single source of truth — Vite reads it for the UI footer, Makefile reads it for Docker build args

## Test plan

- [ ] `cd ui && npx tsc --noEmit` passes
- [ ] `cd ui && npx eslint .` passes (0 errors)
- [ ] `cd ui && npm test` passes (76/76 tests)
- [ ] `grep "0.2.0" ui/package.json Dockerfile CHANGELOG.md CLAUDE.md` shows all files updated
- [ ] No stale `0.1.0` references outside historical CHANGELOG entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)