### PR TITLE
feat: add favorites/pin runbooks to top of list

### DIFF
--- a/ui/src/components/RunbookCard.tsx
+++ b/ui/src/components/RunbookCard.tsx
@@ -15,7 +15,10 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import StarIcon from "@mui/icons-material/Star";
+import StarBorderIcon from "@mui/icons-material/StarBorder";
 import type { Runbook, Category } from "../types";
+import { useRunbooks } from "../context/RunbookContext";
 import { VARIABLE_REGEX, escapeHtml } from "../utils/variables";
 import { RunbookFormDialog } from "./RunbookFormDialog";
 import { RunbookDeleteDialog } from "./RunbookDeleteDialog";
@@ -31,6 +34,7 @@ interface RunbookCardProps {
 }
 
 export function RunbookCard({ runbook, category, collapsed = false, onToggleCollapse, compact = false }: RunbookCardProps) {
+  const { togglePin } = useRunbooks();
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [execOpen, setExecOpen] = useState(false);
@@ -57,6 +61,14 @@ export function RunbookCard({ runbook, category, collapsed = false, onToggleColl
               <Chip key={tag} label={tag} size="small" />
             ))}
             <Box sx={{ flex: 1 }} />
+            <IconButton
+              size="small"
+              title={runbook.pinned ? "Unpin" : "Pin"}
+              onClick={() => togglePin(runbook.id)}
+              color={runbook.pinned ? "warning" : "default"}
+            >
+              {runbook.pinned ? <StarIcon fontSize="small" /> : <StarBorderIcon fontSize="small" />}
+            </IconButton>
             <IconButton size="small" color="primary" title="Run" onClick={() => setExecOpen(true)}>
               <PlayArrowIcon fontSize="small" />
             </IconButton>

--- a/ui/src/components/RunbookList.tsx
+++ b/ui/src/components/RunbookList.tsx
@@ -11,6 +11,7 @@ import {
   IconButton,
   Tooltip,
   Collapse,
+  Divider,
 } from "@mui/material";
 import type { SelectChangeEvent } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
@@ -112,6 +113,12 @@ export function RunbookList() {
     }
   }, [filtered, sortBy]);
 
+  const pinSorted = useMemo(() => {
+    const pinned = sorted.filter((r) => r.pinned);
+    const unpinned = sorted.filter((r) => !r.pinned);
+    return { pinned, unpinned, all: [...pinned, ...unpinned] };
+  }, [sorted]);
+
   const groups = useMemo((): PrimaryGroup[] | null => {
     if (groupMode === "none") return null;
 
@@ -119,7 +126,7 @@ export function RunbookList() {
       const catGroups = new Map<string, Runbook[]>();
       const ungrouped: Runbook[] = [];
 
-      for (const r of sorted) {
+      for (const r of pinSorted.all) {
         if (r.categoryId && categoryMap.has(r.categoryId)) {
           if (!catGroups.has(r.categoryId)) catGroups.set(r.categoryId, []);
           catGroups.get(r.categoryId)!.push(r);
@@ -149,7 +156,7 @@ export function RunbookList() {
     const primaryMap = new Map<string, { display: string; items: Runbook[] }>();
     const ungrouped: Runbook[] = [];
 
-    for (const r of sorted) {
+    for (const r of pinSorted.all) {
       if (r.tags.length === 0) {
         ungrouped.push(r);
       } else {
@@ -161,12 +168,15 @@ export function RunbookList() {
       }
     }
 
-    // Within each group, sort by secondary tags then name
+    // Within each group, sort pinned first then by secondary tags then name
     const result: PrimaryGroup[] = [...primaryMap.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([, { display, items }]) => ({
         tag: display,
         runbooks: items.sort((a, b) => {
+          const aPinned = a.pinned ? 0 : 1;
+          const bPinned = b.pinned ? 0 : 1;
+          if (aPinned !== bPinned) return aPinned - bPinned;
           const aSub = a.tags.slice(1).join("/");
           const bSub = b.tags.slice(1).join("/");
           return aSub.localeCompare(bSub) || a.name.localeCompare(b.name);
@@ -177,7 +187,7 @@ export function RunbookList() {
       result.push({ tag: "Ungrouped", runbooks: ungrouped });
     }
     return result;
-  }, [sorted, groupMode, categories, categoryMap]);
+  }, [pinSorted, groupMode, categories, categoryMap]);
 
   const toggleCollapse = (key: string) => {
     setCollapsed((prev) => {
@@ -233,7 +243,7 @@ export function RunbookList() {
   };
 
   const expandAllCards = () => setCollapsedCards(new Set());
-  const collapseAllCards = () => setCollapsedCards(new Set(sorted.map((r) => r.id)));
+  const collapseAllCards = () => setCollapsedCards(new Set(pinSorted.all.map((r) => r.id)));
 
   const totalInGroup = (g: PrimaryGroup) => g.runbooks.length;
 
@@ -335,7 +345,7 @@ export function RunbookList() {
       </Stack>
 
       {/* Content */}
-      {sorted.length === 0 ? (
+      {pinSorted.all.length === 0 ? (
         <Box
           sx={{
             flex: 1,
@@ -392,8 +402,20 @@ export function RunbookList() {
           </Stack>
         </Box>
       ) : (
-        <Box sx={{ flex: 1, overflow: "auto", ...layoutSx }}>
-          {sorted.map(renderCard)}
+        <Box sx={{ flex: 1, overflow: "auto" }}>
+          {pinSorted.pinned.length > 0 && (
+            <>
+              <Divider textAlign="left" sx={{ mb: 0.75 }}>
+                <Chip label="Pinned" size="small" color="warning" variant="outlined" />
+              </Divider>
+              <Box sx={{ ...layoutSx, mb: 1 }}>
+                {pinSorted.pinned.map(renderCard)}
+              </Box>
+            </>
+          )}
+          <Box sx={layoutSx}>
+            {pinSorted.unpinned.map(renderCard)}
+          </Box>
         </Box>
       )}
     </Box>

--- a/ui/src/context/RunbookContext.tsx
+++ b/ui/src/context/RunbookContext.tsx
@@ -7,6 +7,7 @@ interface RunbookContextValue {
   addRunbook: (data: Omit<Runbook, "id" | "createdAt" | "updatedAt">) => void;
   updateRunbook: (id: string, updates: Partial<Omit<Runbook, "id" | "createdAt">>) => void;
   deleteRunbook: (id: string) => void;
+  togglePin: (id: string) => void;
   replaceAll: (runbooks: Runbook[]) => void;
   restoreDefaults: () => number;
 }
@@ -55,6 +56,16 @@ export function RunbookProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  const togglePin = useCallback((id: string) => {
+    setRunbooks((prev) => {
+      const next = prev.map((r) =>
+        r.id === id ? { ...r, pinned: !r.pinned, updatedAt: new Date().toISOString() } : r,
+      );
+      saveRunbooks(next);
+      return next;
+    });
+  }, []);
+
   const replaceAll = useCallback((imported: Runbook[]) => {
     saveRunbooks(imported);
     setRunbooks(imported);
@@ -73,7 +84,7 @@ export function RunbookProvider({ children }: { children: ReactNode }) {
   }, [runbooks]);
 
   return (
-    <RunbookContext.Provider value={{ runbooks, addRunbook, updateRunbook, deleteRunbook, replaceAll, restoreDefaults }}>
+    <RunbookContext.Provider value={{ runbooks, addRunbook, updateRunbook, deleteRunbook, togglePin, replaceAll, restoreDefaults }}>
       {children}
     </RunbookContext.Provider>
   );

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -5,6 +5,7 @@ export interface Runbook {
   commands: string[];
   tags: string[];
   categoryId?: string;
+  pinned?: boolean;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- Add star/pin button on each runbook card (gold star when pinned)
- Pinned runbooks appear at top in flat mode with "Pinned" divider
- Pinned runbooks sort first within each group in grouped mode
- Optional `pinned` field on Runbook type for backward compatibility

## Test plan
- [ ] Pin a runbook — star turns gold, runbook moves to top
- [ ] Unpin — star clears, runbook returns to normal sort position
- [ ] Verify pinned order persists across page reloads
- [ ] Check flat mode shows "Pinned" divider when pins exist
- [ ] Check grouped mode sorts pinned first within each group

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)