### PR TITLE
feat: stream command output in real-time

### DIFF
--- a/ui/src/components/RunbookExecutionDialog.tsx
+++ b/ui/src/components/RunbookExecutionDialog.tsx
@@ -12,8 +12,11 @@ import {
   List,
   ListItem,
   ListItemText,
+  Switch,
+  FormControlLabel,
 } from "@mui/material";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import type { ExecProcess } from "@docker/extension-api-client-types/dist/v1/exec";
 import type { Runbook, CommandResult, ExecutionStatus } from "../types";
 import { useDockerDesktopClient } from "../App";
 import { getDestructiveWarnings, type DestructiveWarning } from "../utils/destructive-commands";
@@ -43,63 +46,136 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
   const [warnings, setWarnings] = useState<DestructiveWarning[]>([]);
   const [needsParameters, setNeedsParameters] = useState(false);
   const [resolvedCommands, setResolvedCommands] = useState<string[] | null>(null);
+  const [streamOutput, setStreamOutput] = useState("");
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [autoScroll, setAutoScroll] = useState(true);
   const abortRef = useRef(false);
+  const processRef = useRef<ExecProcess | null>(null);
+  const outputContainerRef = useRef<HTMLElement | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const execute = useCallback(async (cmds?: string[]) => {
-    const commands = cmds ?? resolvedCommands ?? runbook.commands;
-    abortRef.current = false;
-    setStatus("running");
-    setResults([]);
-    setCurrentIndex(0);
+  const startTimer = useCallback(() => {
+    setElapsedSeconds(0);
+    timerRef.current = setInterval(() => {
+      setElapsedSeconds((prev) => prev + 1);
+    }, 1000);
+  }, []);
 
-    const collected: CommandResult[] = [];
+  const stopTimer = useCallback(() => {
+    if (timerRef.current != null) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
 
-    for (let i = 0; i < commands.length; i++) {
-      if (abortRef.current) break;
-      setCurrentIndex(i);
+  const scrollToBottom = useCallback(() => {
+    if (autoScroll && outputContainerRef.current != null) {
+      outputContainerRef.current.scrollTop = outputContainerRef.current.scrollHeight;
+    }
+  }, [autoScroll]);
 
-      const raw = commands[i].trim();
-      const tokens = parseCommand(raw);
-      const start = performance.now();
+  const execStreaming = useCallback(
+    (cmd: string, args: string[], rawCommand: string): Promise<CommandResult> => {
+      return new Promise((resolve) => {
+        let stdout = "";
+        let stderr = "";
+        const startTime = Date.now();
 
-      try {
-        const result = await ddClient.docker.cli.exec(tokens[0], tokens.slice(1));
-        const duration = Math.round(performance.now() - start);
-        collected.push({
-          command: raw,
-          stdout: result.stdout,
-          stderr: result.stderr,
-          exitCode: 0,
-          duration,
+        const process = ddClient.docker.cli.exec(cmd, args, {
+          stream: {
+            onOutput: (data) => {
+              if (data.stdout) {
+                stdout += data.stdout;
+                setStreamOutput((prev) => prev + data.stdout);
+              }
+              if (data.stderr) {
+                stderr += data.stderr;
+                setStreamOutput((prev) => prev + data.stderr);
+              }
+            },
+            onClose: (exitCode) => {
+              processRef.current = null;
+              resolve({
+                command: rawCommand,
+                stdout,
+                stderr,
+                exitCode,
+                duration: Date.now() - startTime,
+              });
+            },
+            onError: (error) => {
+              processRef.current = null;
+              resolve({
+                command: rawCommand,
+                stdout,
+                stderr: stderr || String(error),
+                exitCode: 1,
+                duration: Date.now() - startTime,
+              });
+            },
+            splitOutputLines: true,
+          },
         });
-      } catch (err: unknown) {
-        const duration = Math.round(performance.now() - start);
-        const message = err instanceof Error ? err.message : String(err);
-        collected.push({
-          command: raw,
-          stdout: "",
-          stderr: message,
-          exitCode: 1,
-          duration,
-        });
-        setResults([...collected]);
+
+        processRef.current = process;
+      });
+    },
+    [ddClient],
+  );
+
+  const execute = useCallback(
+    async (cmds?: string[]) => {
+      const commands = cmds ?? resolvedCommands ?? runbook.commands;
+      abortRef.current = false;
+      processRef.current = null;
+      setStatus("running");
+      setResults([]);
+      setCurrentIndex(0);
+      setStreamOutput("");
+      startTimer();
+
+      const collected: CommandResult[] = [];
+
+      for (let i = 0; i < commands.length; i++) {
+        if (abortRef.current) break;
         setCurrentIndex(i);
-        setStatus("failed");
-        ddClient.desktopUI.toast.error(`Runbook failed: ${runbook.name}`);
-        return;
+        setStreamOutput("");
+
+        const raw = commands[i].trim();
+        const tokens = parseCommand(raw);
+
+        const result = await execStreaming(tokens[0], tokens.slice(1), raw);
+
+        collected.push(result);
+        setResults([...collected]);
+
+        if (result.exitCode !== 0) {
+          stopTimer();
+          setCurrentIndex(i);
+          setStatus("failed");
+          ddClient.desktopUI.toast.error(`Runbook failed: ${runbook.name}`);
+          return;
+        }
       }
 
-      setResults([...collected]);
-    }
+      stopTimer();
 
-    if (abortRef.current) {
-      setStatus("idle");
-    } else {
-      setStatus("completed");
-      ddClient.desktopUI.toast.success(`Runbook completed: ${runbook.name}`);
-    }
-    setCurrentIndex(-1);
-  }, [ddClient, runbook, resolvedCommands]);
+      if (abortRef.current) {
+        setStatus("idle");
+      } else {
+        setStatus("completed");
+        ddClient.desktopUI.toast.success(`Runbook completed: ${runbook.name}`);
+      }
+      setCurrentIndex(-1);
+      setStreamOutput("");
+    },
+    [ddClient, runbook, resolvedCommands, execStreaming, startTimer, stopTimer],
+  );
+
+  // Auto-scroll when streamOutput changes
+  useEffect(() => {
+    scrollToBottom();
+  }, [streamOutput, scrollToBottom]);
 
   useEffect(() => {
     if (open) {
@@ -117,6 +193,8 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
     }
     return () => {
       abortRef.current = true;
+      processRef.current?.close();
+      stopTimer();
     };
     // Run once when dialog opens
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -124,6 +202,9 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
 
   const handleClose = () => {
     abortRef.current = true;
+    processRef.current?.close();
+    processRef.current = null;
+    stopTimer();
     setStatus("idle");
     setResults([]);
     setCurrentIndex(-1);
@@ -131,7 +212,15 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
     setNeedsParameters(false);
     setResolvedCommands(null);
     setWarnings([]);
+    setStreamOutput("");
+    setElapsedSeconds(0);
     onClose();
+  };
+
+  const handleAbort = () => {
+    abortRef.current = true;
+    processRef.current?.close();
+    processRef.current = null;
   };
 
   const handleConfirm = () => {
@@ -203,40 +292,76 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
     );
   }
 
+  const commands = resolvedCommands ?? runbook.commands;
+
   return (
     <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
       <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
         Running: {runbook.name}
         {status === "running" && <CircularProgress size={20} />}
+        {status === "running" && (
+          <Typography variant="body2" color="text.secondary" sx={{ ml: "auto" }}>
+            Elapsed: {elapsedSeconds}s
+          </Typography>
+        )}
       </DialogTitle>
       <DialogContent>
         <Stack spacing={2}>
-          {(resolvedCommands ?? runbook.commands).map((cmd, i) => (
-            <Box key={i}>
-              <Typography variant="subtitle2" sx={{ fontFamily: "monospace" }}>
-                $ {cmd}
-                {i === currentIndex && status === "running" && " (running...)"}
-              </Typography>
-              {results[i] && (
-                <Box
-                  component="pre"
-                  sx={{
-                    bgcolor: results[i].exitCode === 0 ? "action.hover" : "error.main",
-                    color: results[i].exitCode === 0 ? "text.primary" : "error.contrastText",
-                    p: 1.5,
-                    borderRadius: 1,
-                    fontSize: "0.8rem",
-                    overflow: "auto",
-                    maxHeight: 200,
-                    m: 0,
-                    mt: 0.5,
-                  }}
-                >
-                  {results[i].stdout || results[i].stderr || "(no output)"}
-                </Box>
-              )}
-            </Box>
-          ))}
+          {commands.map((cmd, i) => {
+            const isCurrentCommand = i === currentIndex && status === "running";
+
+            return (
+              <Box key={i}>
+                <Typography variant="subtitle2" sx={{ fontFamily: "monospace" }}>
+                  $ {cmd}
+                  {isCurrentCommand && " (running...)"}
+                </Typography>
+
+                {/* Live streaming output for the currently running command */}
+                {isCurrentCommand && streamOutput !== "" && (
+                  <Box
+                    ref={outputContainerRef}
+                    sx={{
+                      bgcolor: "action.hover",
+                      color: "text.primary",
+                      p: 1.5,
+                      borderRadius: 1,
+                      fontSize: "0.8rem",
+                      fontFamily: "monospace",
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-all",
+                      overflow: "auto",
+                      maxHeight: 300,
+                      m: 0,
+                      mt: 0.5,
+                    }}
+                  >
+                    {streamOutput}
+                  </Box>
+                )}
+
+                {/* Final result for completed commands */}
+                {results[i] != null && (
+                  <Box
+                    component="pre"
+                    sx={{
+                      bgcolor: results[i].exitCode === 0 ? "action.hover" : "error.main",
+                      color: results[i].exitCode === 0 ? "text.primary" : "error.contrastText",
+                      p: 1.5,
+                      borderRadius: 1,
+                      fontSize: "0.8rem",
+                      overflow: "auto",
+                      maxHeight: 200,
+                      m: 0,
+                      mt: 0.5,
+                    }}
+                  >
+                    {results[i].stdout || results[i].stderr || "(no output)"}
+                  </Box>
+                )}
+              </Box>
+            );
+          })}
         </Stack>
       </DialogContent>
       <DialogActions>
@@ -250,8 +375,21 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
             Execution stopped due to error
           </Typography>
         )}
+        {status === "running" && (
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={autoScroll}
+                onChange={(e) => setAutoScroll(e.target.checked)}
+              />
+            }
+            label={<Typography variant="body2">Auto-scroll</Typography>}
+            sx={{ mr: "auto", ml: 1 }}
+          />
+        )}
         {status === "running" ? (
-          <Button onClick={() => { abortRef.current = true; }} color="error">
+          <Button onClick={handleAbort} color="error">
             Abort
           </Button>
         ) : (


### PR DESCRIPTION
## Summary
- Replace buffered Docker CLI execution with streaming API for live output
- Add auto-scroll toggle (Switch in dialog actions, default on)
- Add elapsed timer showing seconds during execution
- Proper abort via ExecProcess.close() for immediate termination

## Test plan
- [ ] Execute a long-running command — output appears line by line
- [ ] Toggle auto-scroll off — output stops scrolling, can scroll manually
- [ ] Abort mid-execution — process terminates cleanly
- [ ] Verify elapsed timer increments during execution and stops on completion
- [ ] Verify multi-command runbooks execute sequentially with streaming

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)