### PR TITLE
feat: add execution history with last-run display

### DIFF
--- a/ui/src/components/RunbookCard.tsx
+++ b/ui/src/components/RunbookCard.tsx
@@ -19,6 +19,7 @@ import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
 import type { Runbook, Category } from "../types";
 import { useRunbooks } from "../context/RunbookContext";
+import { getLastRun, formatTimeAgo } from "../utils/execution-history";
 import { VARIABLE_REGEX, escapeHtml } from "../utils/variables";
 import { RunbookFormDialog } from "./RunbookFormDialog";
 import { RunbookDeleteDialog } from "./RunbookDeleteDialog";
@@ -38,6 +39,7 @@ export function RunbookCard({ runbook, category, collapsed = false, onToggleColl
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [execOpen, setExecOpen] = useState(false);
+  const lastRun = getLastRun(runbook.id);
 
   return (
     <>
@@ -91,6 +93,11 @@ export function RunbookCard({ runbook, category, collapsed = false, onToggleColl
               {runbook.description && (
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
                   {runbook.description}
+                </Typography>
+              )}
+              {lastRun != null && (
+                <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+                  Last run: {formatTimeAgo(lastRun.timestamp)} ({lastRun.exitCode === 0 ? "success" : "failed"})
                 </Typography>
               )}
               <Box

--- a/ui/src/components/RunbookExecutionDialog.tsx
+++ b/ui/src/components/RunbookExecutionDialog.tsx
@@ -20,6 +20,7 @@ import type { ExecProcess } from "@docker/extension-api-client-types/dist/v1/exe
 import type { Runbook, CommandResult, ExecutionStatus } from "../types";
 import { useDockerDesktopClient } from "../App";
 import { getDestructiveWarnings, type DestructiveWarning } from "../utils/destructive-commands";
+import { recordExecution } from "../utils/execution-history";
 import { hasVariables } from "../utils/variables";
 import { ParameterInputDialog } from "./ParameterInputDialog";
 
@@ -153,6 +154,9 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
           stopTimer();
           setCurrentIndex(i);
           setStatus("failed");
+          const totalDuration = collected.reduce((sum, r) => sum + r.duration, 0);
+          const allOutput = collected.map((r) => r.stdout).join("\n");
+          recordExecution(runbook.id, result.exitCode, totalDuration, commands.length, allOutput);
           ddClient.desktopUI.toast.error(`Runbook failed: ${runbook.name}`);
           return;
         }
@@ -164,6 +168,9 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
         setStatus("idle");
       } else {
         setStatus("completed");
+        const totalDuration = collected.reduce((sum, r) => sum + r.duration, 0);
+        const allOutput = collected.map((r) => r.stdout).join("\n");
+        recordExecution(runbook.id, 0, totalDuration, commands.length, allOutput);
         ddClient.desktopUI.toast.success(`Runbook completed: ${runbook.name}`);
       }
       setCurrentIndex(-1);

--- a/ui/src/components/RunbookList.tsx
+++ b/ui/src/components/RunbookList.tsx
@@ -27,6 +27,7 @@ import DensitySmallIcon from "@mui/icons-material/DensitySmall";
 import { useRunbooks } from "../context/RunbookContext";
 import { useCategories } from "../context/CategoryContext";
 import { loadPreference, savePreference } from "../storage";
+import { getLastRun } from "../utils/execution-history";
 import type { SortOption, LayoutMode, GroupMode, Runbook, Category } from "../types";
 import { RunbookCard } from "./RunbookCard";
 import { CategoryBadge } from "./CategoryBadge";
@@ -108,6 +109,15 @@ export function RunbookList() {
         return arr.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
       case "modified-asc":
         return arr.sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
+      case "last-run-desc":
+        return arr.sort((a, b) => {
+          const aLast = getLastRun(a.id);
+          const bLast = getLastRun(b.id);
+          if (aLast == null && bLast == null) return 0;
+          if (aLast == null) return 1;
+          if (bLast == null) return -1;
+          return bLast.timestamp.localeCompare(aLast.timestamp);
+        });
       default:
         return arr;
     }
@@ -310,6 +320,7 @@ export function RunbookList() {
           <MenuItem value="created-asc">Oldest</MenuItem>
           <MenuItem value="modified-desc">Recently Modified</MenuItem>
           <MenuItem value="modified-asc">Least Recently Modified</MenuItem>
+          <MenuItem value="last-run-desc">Recently Executed</MenuItem>
         </Select>
         <Tooltip title={layoutMode === "grid" ? "Switch to list view" : "Switch to grid view"} placement="bottom">
           <IconButton size="small" onClick={handleLayoutToggle}>

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -20,7 +20,15 @@ export interface CommandResult {
 
 export type ExecutionStatus = "idle" | "running" | "completed" | "failed";
 
-export type SortOption = "name-asc" | "name-desc" | "created-desc" | "created-asc" | "modified-desc" | "modified-asc";
+export interface ExecutionHistoryEntry {
+  timestamp: string;
+  exitCode: number;
+  duration: number;
+  commandCount: number;
+  outputSnippet: string;
+}
+
+export type SortOption = "name-asc" | "name-desc" | "created-desc" | "created-asc" | "modified-desc" | "modified-asc" | "last-run-desc";
 
 export type LayoutMode = "grid" | "list";
 

--- a/ui/src/utils/execution-history.ts
+++ b/ui/src/utils/execution-history.ts
@@ -1,0 +1,45 @@
+import { loadPreference, savePreference } from "../storage";
+import type { ExecutionHistoryEntry } from "../types";
+
+const MAX_ENTRIES = 20;
+const SNIPPET_MAX_LENGTH = 200;
+
+export function getHistory(runbookId: string): ExecutionHistoryEntry[] {
+  return loadPreference<ExecutionHistoryEntry[]>(`exec-history-${runbookId}`, []);
+}
+
+export function recordExecution(
+  runbookId: string,
+  exitCode: number,
+  duration: number,
+  commandCount: number,
+  output: string,
+): void {
+  const history = getHistory(runbookId);
+  const entry: ExecutionHistoryEntry = {
+    timestamp: new Date().toISOString(),
+    exitCode,
+    duration,
+    commandCount,
+    outputSnippet: output.slice(0, SNIPPET_MAX_LENGTH),
+  };
+  const updated = [entry, ...history].slice(0, MAX_ENTRIES);
+  savePreference(`exec-history-${runbookId}`, updated);
+}
+
+export function getLastRun(runbookId: string): ExecutionHistoryEntry | null {
+  const history = getHistory(runbookId);
+  return history.length > 0 ? history[0] : null;
+}
+
+export function formatTimeAgo(timestamp: string): string {
+  const diff = Date.now() - new Date(timestamp).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}


### PR DESCRIPTION
## Summary
- Track per-runbook execution history in localStorage (capped at 20 entries)
- Show "Last run: Xm ago (success/failed)" caption on each runbook card
- Add "Recently Executed" sort option (never-run runbooks sort last)
- New `execution-history.ts` utility with `recordExecution`, `getLastRun`, `formatTimeAgo`

## Test plan
- [ ] Execute a runbook — verify "Last run: just now (success)" appears on card
- [ ] Execute a failing command — verify "(failed)" status shown
- [ ] Sort by "Recently Executed" — last-run items appear first, never-run items last
- [ ] Verify history persists across page reloads
- [ ] Abort a run — verify no history entry is recorded

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)