### PR TITLE
feat: derive tag suggestions from existing runbooks

### DIFF
--- a/ui/src/components/RunbookFormDialog.tsx
+++ b/ui/src/components/RunbookFormDialog.tsx
@@ -30,8 +30,6 @@ import {
 } from "../docker-commands";
 import { parseVariables } from "../utils/variables";
 
-const COMMON_TAGS = ["info", "cleanup", "dev", "production", "maintenance", "monitoring", "caution"];
-
 function validateCommands(raw: string): string[] {
   const warnings: string[] = [];
   const lines = raw.split("\n");
@@ -105,7 +103,7 @@ export function RunbookFormDialog({ open, onClose, runbook }: RunbookFormDialogP
   );
 
   const allTags = useMemo(() => {
-    const tagSet = new Set(COMMON_TAGS);
+    const tagSet = new Set<string>();
     for (const r of runbooks) {
       for (const t of r.tags) {
         tagSet.add(t);


### PR DESCRIPTION
## Summary
- Remove hardcoded COMMON_TAGS constant
- Tag autocomplete now suggests only tags from existing runbooks
- freeSolo still allows typing arbitrary new tags

## Test plan
- [ ] Existing runbooks' tags appear in autocomplete dropdown
- [ ] New arbitrary tags can still be typed and added
- [ ] Fresh install with no runbooks shows empty suggestions (expected)

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)