### PR TITLE
feat: add keyboard shortcuts for power users

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { createDockerDesktopClient } from "@docker/extension-api-client";
 import {
   Box, Typography, Stack, Button, IconButton, Tooltip,
@@ -39,6 +39,17 @@ export default function App() {
   const [helpAnchor, setHelpAnchor] = useState<null | HTMLElement>(null);
   const [diagnosticType, setDiagnosticType] = useState<"bug" | "feature" | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key === "n") {
+        e.preventDefault();
+        setFormOpen(true);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
 
   const handleExport = () => {
     exportRunbooks(runbooks, categories);
@@ -128,9 +139,11 @@ export default function App() {
               <ListItemText>Support this Project</ListItemText>
             </MenuItem>
           </Menu>
-          <Button variant="contained" startIcon={<AddIcon />} onClick={() => setFormOpen(true)}>
-            New Runbook
-          </Button>
+          <Tooltip title="Create a new runbook (Ctrl+N)">
+            <Button variant="contained" startIcon={<AddIcon />} onClick={() => setFormOpen(true)}>
+              New Runbook
+            </Button>
+          </Tooltip>
         </Stack>
       </Stack>
 

--- a/ui/src/__tests__/RunbookList.test.tsx
+++ b/ui/src/__tests__/RunbookList.test.tsx
@@ -102,7 +102,7 @@ describe("RunbookList", () => {
   it("search filters runbooks by name", () => {
     seedRunbooks(testRunbooks);
     renderList();
-    const searchInput = screen.getByPlaceholderText("Search runbooks...");
+    const searchInput = screen.getByPlaceholderText("Search runbooks... (/)");
     fireEvent.change(searchInput, { target: { value: "Alpha" } });
     expect(screen.getByText("Alpha Runbook")).toBeInTheDocument();
     expect(screen.queryByText("Beta Runbook")).not.toBeInTheDocument();
@@ -112,7 +112,7 @@ describe("RunbookList", () => {
   it("search filters runbooks by tag", () => {
     seedRunbooks(testRunbooks);
     renderList();
-    const searchInput = screen.getByPlaceholderText("Search runbooks...");
+    const searchInput = screen.getByPlaceholderText("Search runbooks... (/)");
     fireEvent.change(searchInput, { target: { value: "cleanup" } });
     expect(screen.getByText("Beta Runbook")).toBeInTheDocument();
     expect(screen.queryByText("Alpha Runbook")).not.toBeInTheDocument();
@@ -121,7 +121,7 @@ describe("RunbookList", () => {
   it("shows no-match message when search yields nothing", () => {
     seedRunbooks(testRunbooks);
     renderList();
-    const searchInput = screen.getByPlaceholderText("Search runbooks...");
+    const searchInput = screen.getByPlaceholderText("Search runbooks... (/)");
     fireEvent.change(searchInput, { target: { value: "zzz-nonexistent" } });
     expect(screen.getByText(/No runbooks match/)).toBeInTheDocument();
   });

--- a/ui/src/components/CommandEditor.tsx
+++ b/ui/src/components/CommandEditor.tsx
@@ -77,9 +77,10 @@ function highlightDocker(code: string): string {
 interface CommandEditorProps {
   value: string;
   onChange: (value: string) => void;
+  onSubmit?: () => void;
 }
 
-export function CommandEditor({ value, onChange }: CommandEditorProps) {
+export function CommandEditor({ value, onChange, onSubmit }: CommandEditorProps) {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
 
@@ -114,6 +115,12 @@ export function CommandEditor({ value, onChange }: CommandEditorProps) {
           onValueChange={onChange}
           highlight={highlightDocker}
           padding={12}
+          onKeyDown={(e) => {
+            if (e.ctrlKey && e.key === "Enter" && onSubmit) {
+              e.preventDefault();
+              onSubmit();
+            }
+          }}
           style={{
             fontFamily: '"Roboto Mono", "Consolas", monospace',
             fontSize: 13,

--- a/ui/src/components/RunbookExecutionDialog.tsx
+++ b/ui/src/components/RunbookExecutionDialog.tsx
@@ -224,11 +224,23 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
     onClose();
   };
 
-  const handleAbort = () => {
+  const handleAbort = useCallback(() => {
     abortRef.current = true;
     processRef.current?.close();
     processRef.current = null;
-  };
+  }, []);
+
+  useEffect(() => {
+    if (status !== "running") return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key === "c") {
+        e.preventDefault();
+        handleAbort();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [status, handleAbort]);
 
   const handleConfirm = () => {
     setNeedsConfirmation(false);

--- a/ui/src/components/RunbookList.tsx
+++ b/ui/src/components/RunbookList.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef, useEffect } from "react";
 import {
   Box,
   Typography,
@@ -57,6 +57,23 @@ export function RunbookList() {
   const { runbooks } = useRunbooks();
   const { categories } = useCategories();
   const [searchQuery, setSearchQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const tag = document.activeElement?.tagName;
+      if (e.key === "/" && tag !== "INPUT" && tag !== "TEXTAREA") {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+      if (e.key === "Escape" && tag === "INPUT") {
+        searchRef.current?.blur();
+        setSearchQuery("");
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
   const [sortBy, setSortBy] = useState<SortOption>(
     () => loadPreference<SortOption>("sortBy", "name-asc"),
   );
@@ -294,9 +311,10 @@ export function RunbookList() {
         <Tooltip title="Filter by name, description, tags, or commands" placement="bottom">
           <TextField
             size="small"
-            placeholder="Search runbooks..."
+            placeholder="Search runbooks... (/)"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
+            inputRef={searchRef}
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">


### PR DESCRIPTION
## Summary
- Ctrl+N: open new runbook form (global)
- /: focus search field when no input focused
- Escape: clear search and blur input
- Ctrl+C: abort running execution
- Ctrl+Enter: submit in command editor (new onSubmit prop)
- Tooltips and placeholders updated with shortcut hints

## Test plan
- [ ] Ctrl+N opens new runbook dialog from anywhere
- [ ] / focuses search field, typing filters runbooks
- [ ] Escape clears search text and blurs input
- [ ] Ctrl+C aborts a running execution
- [ ] Ctrl+Enter in command editor triggers submit callback

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)