### PR TITLE
feat: add dry-run preview before command execution

### DIFF
--- a/ui/src/__tests__/RunbookExecutionDialog.test.tsx
+++ b/ui/src/__tests__/RunbookExecutionDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import type { Runbook } from "../types";
 import { RunbookExecutionDialog } from "../components/RunbookExecutionDialog";
 
@@ -102,108 +102,185 @@ beforeEach(() => {
 });
 
 describe("RunbookExecutionDialog", () => {
-  it("renders dialog with runbook name", async () => {
-    render(
-      <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
-    );
-    await waitFor(() => {
-      expect(screen.getByText(/Test Execution/)).toBeInTheDocument();
+  describe("Preview", () => {
+    it("shows preview when dialog opens", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText(/Preview: Test Execution/)).toBeInTheDocument();
+      });
+      expect(screen.getByText(/Review the commands that will be executed/)).toBeInTheDocument();
+      expect(screen.getByText(/\$ docker ps/)).toBeInTheDocument();
     });
-  });
 
-  it("shows commands in the dialog", async () => {
-    render(
-      <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={multiCommandRunbook} />,
-    );
-    await waitFor(() => {
+    it("shows Run, Copy, Cancel buttons in preview", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Run")).toBeInTheDocument();
+      });
+      expect(screen.getByText("Copy")).toBeInTheDocument();
+      expect(screen.getByText("Cancel")).toBeInTheDocument();
+    });
+
+    it("shows all commands in preview for multi-command runbook", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={multiCommandRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText(/Preview: Multi-Command/)).toBeInTheDocument();
+      });
       expect(screen.getByText(/\$ docker ps/)).toBeInTheDocument();
       expect(screen.getByText(/\$ docker images/)).toBeInTheDocument();
     });
-  });
 
-  it("starts execution automatically when opened", async () => {
-    render(
-      <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
-    );
-    // Should show running state (the title contains "Running:")
-    await waitFor(() => {
-      expect(screen.getByText(/Running:/)).toBeInTheDocument();
-    });
-  });
-
-  it("shows streaming output during execution", async () => {
-    render(
-      <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
-    );
-
-    // Wait for execution to start and streaming to be set up
-    await waitFor(() => {
-      expect(streamCallbacks.onOutput).toBeDefined();
-    });
-
-    // Simulate streaming output (wrap in act to flush state updates)
-    act(() => {
-      streamCallbacks.onOutput?.({ stdout: "container-list-output\n" });
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText(/container-list-output/)).toBeInTheDocument();
-    });
-  });
-
-  it("records execution history on completion", async () => {
-    render(
-      <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
-    );
-
-    await waitFor(() => {
-      expect(streamCallbacks.onClose).toBeDefined();
-    });
-
-    // Complete the execution
-    streamCallbacks.onClose?.(0);
-
-    await waitFor(() => {
-      expect(mockRecordExecution).toHaveBeenCalledWith(
-        "exec-test-1",
-        0,
-        expect.any(Number),
-        1,
-        expect.any(String),
+    it("clicking Cancel in preview closes dialog", async () => {
+      const onClose = vi.fn();
+      render(
+        <RunbookExecutionDialog open={true} onClose={onClose} runbook={simpleRunbook} />,
       );
+      await waitFor(() => {
+        expect(screen.getByText("Cancel")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("Cancel"));
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("clicking Run in preview starts execution", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Run")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("Run"));
+      await waitFor(() => {
+        expect(screen.getByText(/Running:/)).toBeInTheDocument();
+      });
     });
   });
 
-  it("shows success message on completion", async () => {
-    render(
-      <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
-    );
-
-    await waitFor(() => {
-      expect(streamCallbacks.onClose).toBeDefined();
+  describe("Execution (after preview)", () => {
+    it("renders dialog with runbook name in running state", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Run")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("Run"));
+      await waitFor(() => {
+        expect(screen.getByText(/Test Execution/)).toBeInTheDocument();
+      });
     });
 
-    streamCallbacks.onClose?.(0);
-
-    await waitFor(() => {
-      expect(screen.getByText(/All commands completed successfully/)).toBeInTheDocument();
+    it("shows commands in the running dialog", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={multiCommandRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Run")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("Run"));
+      await waitFor(() => {
+        expect(screen.getByText(/Running:/)).toBeInTheDocument();
+      });
+      expect(screen.getByText(/\$ docker ps/)).toBeInTheDocument();
+      expect(screen.getByText(/\$ docker images/)).toBeInTheDocument();
     });
-  });
 
-  it("shows Close button when not running", async () => {
-    render(
-      <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
-    );
+    it("shows streaming output during execution", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Run")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("Run"));
 
-    await waitFor(() => {
-      expect(streamCallbacks.onClose).toBeDefined();
+      // Wait for execution to start and streaming to be set up
+      await waitFor(() => {
+        expect(streamCallbacks.onOutput).toBeDefined();
+      });
+
+      // Simulate streaming output (wrap in act to flush state updates)
+      act(() => {
+        streamCallbacks.onOutput?.({ stdout: "container-list-output\n" });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/container-list-output/)).toBeInTheDocument();
+      });
     });
 
-    // Complete execution to transition out of running state
-    streamCallbacks.onClose?.(0);
+    it("records execution history on completion", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Run")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("Run"));
 
-    await waitFor(() => {
-      expect(screen.getByText("Close")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(streamCallbacks.onClose).toBeDefined();
+      });
+
+      // Complete the execution
+      streamCallbacks.onClose?.(0);
+
+      await waitFor(() => {
+        expect(mockRecordExecution).toHaveBeenCalledWith(
+          "exec-test-1",
+          0,
+          expect.any(Number),
+          1,
+          expect.any(String),
+        );
+      });
+    });
+
+    it("shows success message on completion", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Run")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("Run"));
+
+      await waitFor(() => {
+        expect(streamCallbacks.onClose).toBeDefined();
+      });
+
+      streamCallbacks.onClose?.(0);
+
+      await waitFor(() => {
+        expect(screen.getByText(/All commands completed successfully/)).toBeInTheDocument();
+      });
+    });
+
+    it("shows Close button when not running", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Run")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("Run"));
+
+      await waitFor(() => {
+        expect(streamCallbacks.onClose).toBeDefined();
+      });
+
+      // Complete execution to transition out of running state
+      streamCallbacks.onClose?.(0);
+
+      await waitFor(() => {
+        expect(screen.getByText("Close")).toBeInTheDocument();
+      });
     });
   });
 });

--- a/ui/src/components/RunbookExecutionDialog.tsx
+++ b/ui/src/components/RunbookExecutionDialog.tsx
@@ -47,6 +47,7 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
   const [warnings, setWarnings] = useState<DestructiveWarning[]>([]);
   const [needsParameters, setNeedsParameters] = useState(false);
   const [resolvedCommands, setResolvedCommands] = useState<string[] | null>(null);
+  const [showPreview, setShowPreview] = useState(false);
   const [streamOutput, setStreamOutput] = useState("");
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [autoScroll, setAutoScroll] = useState(true);
@@ -189,13 +190,7 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
       if (hasVariables(runbook.commands)) {
         setNeedsParameters(true);
       } else {
-        const detected = getDestructiveWarnings(runbook.commands);
-        if (detected.length > 0) {
-          setWarnings(detected);
-          setNeedsConfirmation(true);
-        } else {
-          execute();
-        }
+        setShowPreview(true);
       }
     }
     return () => {
@@ -217,6 +212,7 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
     setCurrentIndex(-1);
     setNeedsConfirmation(false);
     setNeedsParameters(false);
+    setShowPreview(false);
     setResolvedCommands(null);
     setWarnings([]);
     setStreamOutput("");
@@ -247,16 +243,32 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
     execute();
   };
 
-  const handleParameterSubmit = (resolved: string[]) => {
-    setNeedsParameters(false);
-    setResolvedCommands(resolved);
-    const detected = getDestructiveWarnings(resolved);
+  const handlePreviewConfirm = () => {
+    setShowPreview(false);
+    const cmds = resolvedCommands ?? runbook.commands;
+    const detected = getDestructiveWarnings(cmds);
     if (detected.length > 0) {
       setWarnings(detected);
       setNeedsConfirmation(true);
     } else {
-      execute(resolved);
+      execute(cmds);
     }
+  };
+
+  const handlePreviewCopy = async () => {
+    const cmds = resolvedCommands ?? runbook.commands;
+    try {
+      await navigator.clipboard.writeText(cmds.join("\n"));
+      ddClient.desktopUI.toast.success("Commands copied to clipboard");
+    } catch {
+      ddClient.desktopUI.toast.error("Failed to copy to clipboard");
+    }
+  };
+
+  const handleParameterSubmit = (resolved: string[]) => {
+    setNeedsParameters(false);
+    setResolvedCommands(resolved);
+    setShowPreview(true);
   };
 
   if (needsParameters) {
@@ -267,6 +279,45 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
         onRun={handleParameterSubmit}
         runbook={runbook}
       />
+    );
+  }
+
+  if (showPreview) {
+    const previewCommands = resolvedCommands ?? runbook.commands;
+    return (
+      <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
+        <DialogTitle>Preview: {runbook.name}</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Review the commands that will be executed:
+          </Typography>
+          <Box
+            component="pre"
+            sx={{
+              bgcolor: "action.hover",
+              color: "text.primary",
+              p: 2,
+              borderRadius: 1,
+              fontSize: "0.85rem",
+              fontFamily: "monospace",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-all",
+              overflow: "auto",
+              maxHeight: 400,
+              m: 0,
+            }}
+          >
+            {previewCommands.map((cmd) => `$ ${cmd}`).join("\n")}
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handlePreviewCopy}>Copy</Button>
+          <Button onClick={handlePreviewConfirm} variant="contained" color="primary">
+            Run
+          </Button>
+        </DialogActions>
+      </Dialog>
     );
   }
 


### PR DESCRIPTION
## Summary
- Adds a preview dialog showing resolved commands before execution
- New flow: open -> variables? -> **preview** -> destructive? -> execute
- Preview shows commands in monospace `<pre>` with Run/Copy/Cancel buttons
- Copy button writes all commands to clipboard with toast feedback

Closes #96

## Test plan
- [x] TypeScript compiles (`npx tsc --noEmit`)
- [x] ESLint passes on modified files
- [x] 116 tests pass (5 new preview tests, existing tests updated for preview step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)