### PR TITLE
feat: add navigation links in execution results

### DIFF
--- a/ui/src/__tests__/RunbookExecutionDialog.test.tsx
+++ b/ui/src/__tests__/RunbookExecutionDialog.test.tsx
@@ -12,7 +12,14 @@ const mockClose = vi.fn();
 vi.mock("@docker/extension-api-client", () => ({
   createDockerDesktopClient: vi.fn(() => ({
     docker: { cli: { exec: vi.fn() } },
-    desktopUI: { toast: { success: vi.fn(), error: vi.fn() } },
+    desktopUI: {
+      toast: { success: vi.fn(), error: vi.fn() },
+      navigate: {
+        viewContainers: vi.fn(),
+        viewImages: vi.fn(),
+        viewVolumes: vi.fn(),
+      },
+    },
     host: { openExternal: vi.fn() },
   })),
 }));
@@ -50,6 +57,10 @@ let streamCallbacks: {
   onError?: (error: unknown) => void;
 } = {};
 
+const mockNavigateContainers = vi.fn();
+const mockNavigateImages = vi.fn();
+const mockNavigateVolumes = vi.fn();
+
 vi.mock("../App", () => ({
   useDockerDesktopClient: vi.fn(() => ({
     docker: {
@@ -67,6 +78,11 @@ vi.mock("../App", () => ({
       toast: {
         success: mockToastSuccess,
         error: mockToastError,
+      },
+      navigate: {
+        viewContainers: mockNavigateContainers,
+        viewImages: mockNavigateImages,
+        viewVolumes: mockNavigateVolumes,
       },
     },
   })),
@@ -92,12 +108,25 @@ const multiCommandRunbook: Runbook = {
   updatedAt: "2026-01-01T00:00:00Z",
 };
 
+const containerRunbook: Runbook = {
+  id: "exec-test-3",
+  name: "Container Runbook",
+  description: "Runbook with container commands",
+  commands: ["docker run nginx"],
+  tags: [],
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
 beforeEach(() => {
   localStorage.clear();
   mockRecordExecution.mockClear();
   mockToastSuccess.mockClear();
   mockToastError.mockClear();
   mockClose.mockClear();
+  mockNavigateContainers.mockClear();
+  mockNavigateImages.mockClear();
+  mockNavigateVolumes.mockClear();
   streamCallbacks = {};
 });
 
@@ -281,6 +310,97 @@ describe("RunbookExecutionDialog", () => {
       await waitFor(() => {
         expect(screen.getByText("Close")).toBeInTheDocument();
       });
+    });
+  });
+
+  describe("Navigation Links", () => {
+    it("shows View Containers button after container command completes", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={containerRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Run")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("Run"));
+
+      await waitFor(() => {
+        expect(streamCallbacks.onClose).toBeDefined();
+      });
+
+      streamCallbacks.onClose?.(0);
+
+      await waitFor(() => {
+        expect(screen.getByText("View Containers")).toBeInTheDocument();
+      });
+    });
+
+    it("calls navigate.viewContainers when View Containers is clicked", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={containerRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Run")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("Run"));
+
+      await waitFor(() => {
+        expect(streamCallbacks.onClose).toBeDefined();
+      });
+
+      streamCallbacks.onClose?.(0);
+
+      await waitFor(() => {
+        expect(screen.getByText("View Containers")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText("View Containers"));
+      expect(mockNavigateContainers).toHaveBeenCalled();
+    });
+
+    it("does not show navigation buttons for non-navigable commands", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={simpleRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Run")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("Run"));
+
+      await waitFor(() => {
+        expect(streamCallbacks.onClose).toBeDefined();
+      });
+
+      streamCallbacks.onClose?.(0);
+
+      await waitFor(() => {
+        expect(screen.getByText("Close")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("View Containers")).not.toBeInTheDocument();
+      expect(screen.queryByText("View Images")).not.toBeInTheDocument();
+      expect(screen.queryByText("View Volumes")).not.toBeInTheDocument();
+    });
+
+    it("shows navigation buttons even when execution fails", async () => {
+      render(
+        <RunbookExecutionDialog open={true} onClose={vi.fn()} runbook={containerRunbook} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("Run")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("Run"));
+
+      await waitFor(() => {
+        expect(streamCallbacks.onClose).toBeDefined();
+      });
+
+      streamCallbacks.onClose?.(1);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Execution stopped due to error/)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("View Containers")).toBeInTheDocument();
     });
   });
 });

--- a/ui/src/__tests__/output-links.test.ts
+++ b/ui/src/__tests__/output-links.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { getNavigationActions } from "../utils/output-links";
+
+describe("getNavigationActions", () => {
+  it("returns empty array for unknown commands", () => {
+    expect(getNavigationActions(["docker version"])).toEqual([]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(getNavigationActions([])).toEqual([]);
+  });
+
+  it("suggests View Containers for run commands", () => {
+    const actions = getNavigationActions(["docker run nginx"]);
+    expect(actions).toEqual([
+      { label: "View Containers", target: "containers" },
+    ]);
+  });
+
+  it("suggests View Images for pull commands", () => {
+    const actions = getNavigationActions(["docker pull nginx"]);
+    expect(actions).toEqual([
+      { label: "View Images", target: "images" },
+    ]);
+  });
+
+  it("suggests View Volumes for volume commands", () => {
+    const actions = getNavigationActions(["docker volume create mydata"]);
+    expect(actions).toEqual([
+      { label: "View Volumes", target: "volumes" },
+    ]);
+  });
+
+  it("deduplicates actions", () => {
+    const actions = getNavigationActions(["docker run a", "docker run b"]);
+    expect(actions).toHaveLength(1);
+  });
+
+  it("returns multiple targets for mixed commands", () => {
+    const actions = getNavigationActions([
+      "docker run nginx",
+      "docker pull alpine",
+      "docker volume ls",
+    ]);
+    expect(actions).toHaveLength(3);
+    expect(actions[0].target).toBe("containers");
+    expect(actions[1].target).toBe("images");
+    expect(actions[2].target).toBe("volumes");
+  });
+
+  it("handles commands without docker prefix", () => {
+    const actions = getNavigationActions(["run nginx"]);
+    expect(actions).toEqual([
+      { label: "View Containers", target: "containers" },
+    ]);
+  });
+
+  it("handles start/stop/restart/kill/exec/create/pause/unpause commands", () => {
+    for (const sub of [
+      "start",
+      "stop",
+      "restart",
+      "kill",
+      "exec",
+      "create",
+      "pause",
+      "unpause",
+    ]) {
+      const actions = getNavigationActions([`docker ${sub} mycontainer`]);
+      expect(actions[0]?.target).toBe("containers");
+    }
+  });
+
+  it("handles build/push/rmi/tag/image/load/save commands", () => {
+    for (const sub of ["build", "push", "rmi", "tag", "image", "load", "save"]) {
+      const actions = getNavigationActions([`docker ${sub} myimage`]);
+      expect(actions[0]?.target).toBe("images");
+    }
+  });
+
+  it("handles rm command as container action", () => {
+    const actions = getNavigationActions(["docker rm mycontainer"]);
+    expect(actions[0]?.target).toBe("containers");
+  });
+
+  it("is case-insensitive", () => {
+    const actions = getNavigationActions(["Docker RUN nginx"]);
+    expect(actions).toEqual([
+      { label: "View Containers", target: "containers" },
+    ]);
+  });
+});

--- a/ui/src/components/RunbookExecutionDialog.tsx
+++ b/ui/src/components/RunbookExecutionDialog.tsx
@@ -21,6 +21,7 @@ import type { Runbook, CommandResult, ExecutionStatus } from "../types";
 import { useDockerDesktopClient } from "../App";
 import { getDestructiveWarnings, type DestructiveWarning } from "../utils/destructive-commands";
 import { recordExecution } from "../utils/execution-history";
+import { getNavigationActions, type NavigationTarget } from "../utils/output-links";
 import { hasVariables } from "../utils/variables";
 import { ParameterInputDialog } from "./ParameterInputDialog";
 
@@ -226,6 +227,20 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
     processRef.current = null;
   }, []);
 
+  const handleNavigate = (target: NavigationTarget) => {
+    switch (target) {
+      case "containers":
+        ddClient.desktopUI.navigate.viewContainers();
+        break;
+      case "images":
+        ddClient.desktopUI.navigate.viewImages();
+        break;
+      case "volumes":
+        ddClient.desktopUI.navigate.viewVolumes();
+        break;
+    }
+  };
+
   useEffect(() => {
     if (status !== "running") return;
     const handler = (e: KeyboardEvent) => {
@@ -363,6 +378,7 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
   }
 
   const commands = resolvedCommands ?? runbook.commands;
+  const navigationActions = getNavigationActions(commands);
 
   return (
     <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
@@ -458,6 +474,21 @@ export function RunbookExecutionDialog({ open, onClose, runbook }: RunbookExecut
             sx={{ mr: "auto", ml: 1 }}
           />
         )}
+        {(status === "completed" || status === "failed") &&
+          navigationActions.length > 0 && (
+            <Stack direction="row" spacing={1}>
+              {navigationActions.map((action) => (
+                <Button
+                  key={action.target}
+                  size="small"
+                  variant="outlined"
+                  onClick={() => handleNavigate(action.target)}
+                >
+                  {action.label}
+                </Button>
+              ))}
+            </Stack>
+          )}
         {status === "running" ? (
           <Button onClick={handleAbort} color="error">
             Abort

--- a/ui/src/utils/output-links.ts
+++ b/ui/src/utils/output-links.ts
@@ -1,0 +1,49 @@
+export type NavigationTarget = "containers" | "images" | "volumes";
+
+export interface NavigationAction {
+  label: string;
+  target: NavigationTarget;
+}
+
+/**
+ * Analyze commands to determine relevant navigation actions.
+ * Returns contextual navigation buttons based on command types.
+ */
+export function getNavigationActions(
+  commands: string[],
+): NavigationAction[] {
+  const actions: NavigationAction[] = [];
+  const seen = new Set<NavigationTarget>();
+
+  for (const cmd of commands) {
+    const lower = cmd.toLowerCase().trim();
+    const normalized = lower.startsWith("docker ")
+      ? lower.slice(7)
+      : lower;
+
+    if (
+      !seen.has("containers") &&
+      /^(run|start|stop|restart|kill|rm|exec|create|pause|unpause)\b/.test(
+        normalized,
+      )
+    ) {
+      actions.push({ label: "View Containers", target: "containers" });
+      seen.add("containers");
+    }
+
+    if (
+      !seen.has("images") &&
+      /^(pull|build|push|rmi|tag|image|load|save)\b/.test(normalized)
+    ) {
+      actions.push({ label: "View Images", target: "images" });
+      seen.add("images");
+    }
+
+    if (!seen.has("volumes") && /^(volume)\b/.test(normalized)) {
+      actions.push({ label: "View Volumes", target: "volumes" });
+      seen.add("volumes");
+    }
+  }
+
+  return actions;
+}


### PR DESCRIPTION
## Summary
- Adds contextual navigation buttons after command execution
- "View Containers" for run/start/stop/exec commands, "View Images" for pull/build, "View Volumes" for volume commands
- Uses Docker Desktop Extension SDK navigate APIs for deep integration
- New `output-links.ts` utility with 12 unit tests

Closes #97

## Test plan
- [x] TypeScript compiles (`npx tsc --noEmit`)
- [x] ESLint passes on all modified files
- [x] 132 tests pass (12 new output-links + 4 new navigation tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)