### PR TITLE
feat: add container/image name autocomplete in command editor

### DIFF
--- a/ui/src/__tests__/useDockerResources.test.ts
+++ b/ui/src/__tests__/useDockerResources.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useDockerResources } from "../hooks/useDockerResources";
+
+vi.mock("../App", () => ({
+  useDockerDesktopClient: vi.fn(() => ({
+    docker: {
+      listContainers: vi.fn(() =>
+        Promise.resolve([
+          { Names: ["/my-nginx"] },
+          { Names: ["/my-redis"] },
+        ]),
+      ),
+      listImages: vi.fn(() =>
+        Promise.resolve([
+          { RepoTags: ["nginx:latest", "nginx:1.25"] },
+          { RepoTags: ["redis:7"] },
+          { RepoTags: ["<none>:<none>"] },
+        ]),
+      ),
+    },
+  })),
+}));
+
+describe("useDockerResources", () => {
+  it("fetches containers and images", async () => {
+    const { result } = renderHook(() => useDockerResources());
+
+    await waitFor(() => {
+      expect(result.current.length).toBeGreaterThan(0);
+    });
+
+    const containers = result.current.filter((r) => r.type === "container");
+    const images = result.current.filter((r) => r.type === "image");
+
+    expect(containers).toContainEqual({ name: "my-nginx", type: "container" });
+    expect(containers).toContainEqual({ name: "my-redis", type: "container" });
+    expect(images).toContainEqual({ name: "nginx:latest", type: "image" });
+    expect(images).toContainEqual({ name: "nginx:1.25", type: "image" });
+    expect(images).toContainEqual({ name: "redis:7", type: "image" });
+    // <none>:<none> should be filtered out
+    expect(images).not.toContainEqual(
+      expect.objectContaining({ name: "<none>:<none>" }),
+    );
+  });
+
+  it("strips leading slash from container names", async () => {
+    const { result } = renderHook(() => useDockerResources());
+
+    await waitFor(() => {
+      expect(result.current.length).toBeGreaterThan(0);
+    });
+
+    const containerNames = result.current
+      .filter((r) => r.type === "container")
+      .map((r) => r.name);
+
+    for (const name of containerNames) {
+      expect(name).not.toMatch(/^\//);
+    }
+  });
+});

--- a/ui/src/components/CommandEditor.tsx
+++ b/ui/src/components/CommandEditor.tsx
@@ -1,7 +1,31 @@
+import { useState, useMemo, useEffect, useCallback } from "react";
 import Editor from "react-simple-code-editor";
-import { Box, FormHelperText, useTheme } from "@mui/material";
+import {
+  Box,
+  FormHelperText,
+  useTheme,
+  Paper,
+  MenuList,
+  MenuItem,
+  Typography,
+  Popper,
+  ClickAwayListener,
+} from "@mui/material";
 import { ALL_COMMANDS, MANAGEMENT_COMMANDS, DOCKER_COMMANDS } from "../docker-commands";
 import { VARIABLE_REGEX, escapeHtml } from "../utils/variables";
+import type { DockerResource } from "../hooks/useDockerResources";
+
+/** Docker CLI commands that typically take a container name/ID as an argument */
+const CONTAINER_COMMANDS = new Set([
+  "exec", "start", "stop", "restart", "kill", "rm", "logs",
+  "inspect", "attach", "commit", "cp", "diff", "export",
+  "port", "rename", "top", "update", "wait",
+]);
+
+/** Docker CLI commands that typically take an image name as an argument */
+const IMAGE_COMMANDS = new Set([
+  "run", "pull", "push", "tag", "rmi", "save", "load", "history",
+]);
 
 /** Regex-based Docker CLI syntax highlighter */
 function highlightDocker(code: string): string {
@@ -74,15 +98,90 @@ function highlightDocker(code: string): string {
     );
 }
 
+/**
+ * Determine what type of Docker resource to suggest based on the
+ * current line's command context.
+ */
+function getSuggestionType(line: string): "container" | "image" | null {
+  const tokens = line.trim().split(/\s+/);
+  let i = 0;
+  if (tokens[i]?.toLowerCase() === "docker") i++;
+
+  const cmd = tokens[i]?.toLowerCase();
+  if (!cmd) return null;
+
+  if (CONTAINER_COMMANDS.has(cmd)) return "container";
+  if (IMAGE_COMMANDS.has(cmd)) return "image";
+
+  // Management commands: "container <sub>" or "image <sub>"
+  if (cmd === "container") return "container";
+  if (cmd === "image") return "image";
+
+  return null;
+}
+
 interface CommandEditorProps {
   value: string;
   onChange: (value: string) => void;
   onSubmit?: () => void;
+  suggestions?: DockerResource[];
 }
 
-export function CommandEditor({ value, onChange, onSubmit }: CommandEditorProps) {
+export function CommandEditor({ value, onChange, onSubmit, suggestions }: CommandEditorProps) {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
+
+  // Use state for the anchor element so it can be read during render
+  // without violating the React Compiler refs-during-render rule.
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+  const editorRefCallback = useCallback((node: HTMLDivElement | null) => {
+    setAnchorEl(node);
+  }, []);
+
+  // Track whether the user dismissed the dropdown (Escape or click-away).
+  const [dismissed, setDismissed] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Reset dismissed state when the user types (value changes)
+  useEffect(() => {
+    setDismissed(false);
+    setSelectedIndex(0);
+  }, [value]);
+
+  // Derive filtered suggestions from value + suggestions (pure computation)
+  const filteredSuggestions = useMemo<DockerResource[]>(() => {
+    if (!suggestions || suggestions.length === 0) return [];
+
+    const lines = value.split("\n");
+    const lastLine = lines[lines.length - 1] ?? "";
+    const tokens = lastLine.trim().split(/\s+/);
+    const lastToken = tokens[tokens.length - 1] ?? "";
+
+    const type = getSuggestionType(lastLine);
+    if (!type || tokens.length < 2 || lastToken.length === 0) return [];
+
+    return suggestions
+      .filter((s) => s.type === type && s.name.toLowerCase().includes(lastToken.toLowerCase()))
+      .slice(0, 8);
+  }, [value, suggestions]);
+
+  const showSuggestions = filteredSuggestions.length > 0 && !dismissed;
+
+  // Accept a suggestion by replacing the last token on the current line
+  const acceptSuggestion = useCallback(
+    (name: string) => {
+      const lines = value.split("\n");
+      const lastLine = lines[lines.length - 1] ?? "";
+      const tokens = lastLine.trim().split(/\s+/);
+
+      tokens[tokens.length - 1] = name;
+      lines[lines.length - 1] = tokens.join(" ");
+
+      onChange(lines.join("\n"));
+      setDismissed(true);
+    },
+    [value, onChange],
+  );
 
   const cssVars = {
     "--docker-command": isDark ? "#6cb6ff" : "#0550ae",
@@ -97,6 +196,7 @@ export function CommandEditor({ value, onChange, onSubmit }: CommandEditorProps)
   return (
     <Box sx={cssVars}>
       <Box
+        ref={editorRefCallback}
         sx={{
           border: 1,
           borderColor: "divider",
@@ -116,6 +216,30 @@ export function CommandEditor({ value, onChange, onSubmit }: CommandEditorProps)
           highlight={highlightDocker}
           padding={12}
           onKeyDown={(e) => {
+            if (showSuggestions && filteredSuggestions.length > 0) {
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setSelectedIndex((prev) =>
+                  Math.min(prev + 1, filteredSuggestions.length - 1),
+                );
+                return;
+              }
+              if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setSelectedIndex((prev) => Math.max(prev - 1, 0));
+                return;
+              }
+              if (e.key === "Tab" || e.key === "Enter") {
+                e.preventDefault();
+                acceptSuggestion(filteredSuggestions[selectedIndex].name);
+                return;
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                setDismissed(true);
+                return;
+              }
+            }
             if (e.ctrlKey && e.key === "Enter" && onSubmit) {
               e.preventDefault();
               onSubmit();
@@ -132,6 +256,42 @@ export function CommandEditor({ value, onChange, onSubmit }: CommandEditorProps)
           textareaClassName="command-editor-textarea"
         />
       </Box>
+      {showSuggestions && anchorEl != null && (
+        <ClickAwayListener onClickAway={() => setDismissed(true)}>
+          <Popper
+            open={showSuggestions}
+            anchorEl={anchorEl}
+            placement="bottom-start"
+            style={{ zIndex: 1301, width: anchorEl.clientWidth }}
+          >
+            <Paper elevation={8} sx={{ maxHeight: 200, overflow: "auto" }}>
+              <MenuList dense>
+                {filteredSuggestions.map((s, i) => (
+                  <MenuItem
+                    key={`${s.type}-${s.name}`}
+                    selected={i === selectedIndex}
+                    onClick={() => acceptSuggestion(s.name)}
+                  >
+                    <Typography
+                      variant="body2"
+                      sx={{ fontFamily: "monospace", fontSize: "0.85rem" }}
+                    >
+                      {s.name}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ ml: 1 }}
+                    >
+                      {s.type}
+                    </Typography>
+                  </MenuItem>
+                ))}
+              </MenuList>
+            </Paper>
+          </Popper>
+        </ClickAwayListener>
+      )}
       <FormHelperText>
         &quot;docker&quot; prefix is optional. Use {"{{name}}"} for variables.
       </FormHelperText>

--- a/ui/src/components/RunbookFormDialog.tsx
+++ b/ui/src/components/RunbookFormDialog.tsx
@@ -22,6 +22,7 @@ import { useRunbooks } from "../context/RunbookContext";
 import { useCategories } from "../context/CategoryContext";
 import { ICON_LABELS } from "../category-defaults";
 import { CommandEditor } from "./CommandEditor";
+import { useDockerResources } from "../hooks/useDockerResources";
 import {
   DOCKER_COMMANDS,
   ALL_COMMANDS,
@@ -88,6 +89,7 @@ interface RunbookFormDialogProps {
 export function RunbookFormDialog({ open, onClose, runbook }: RunbookFormDialogProps) {
   const { runbooks, addRunbook, updateRunbook } = useRunbooks();
   const { categories } = useCategories();
+  const dockerResources = useDockerResources();
   const isEdit = Boolean(runbook);
 
   const [name, setName] = useState("");
@@ -197,7 +199,7 @@ export function RunbookFormDialog({ open, onClose, runbook }: RunbookFormDialogP
             <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
               Commands (one per line) *
             </Typography>
-            <CommandEditor value={commands} onChange={setCommands} />
+            <CommandEditor value={commands} onChange={setCommands} suggestions={dockerResources} />
             <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: "block" }}>
               Paste commands directly from terminals or docs. The &quot;docker&quot; prefix is optional.
             </Typography>

--- a/ui/src/hooks/useDockerResources.ts
+++ b/ui/src/hooks/useDockerResources.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect } from "react";
+import { useDockerDesktopClient } from "../App";
+
+export interface DockerResource {
+  name: string;
+  type: "container" | "image";
+}
+
+interface ContainerInfo {
+  Names?: string[];
+}
+
+interface ImageInfo {
+  RepoTags?: string[];
+}
+
+export function useDockerResources(): DockerResource[] {
+  const ddClient = useDockerDesktopClient();
+  const [resources, setResources] = useState<DockerResource[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchResources() {
+      const items: DockerResource[] = [];
+
+      try {
+        const raw = await ddClient.docker.listContainers({ all: true });
+        const containers = raw as ContainerInfo[];
+        for (const c of containers) {
+          const names = c.Names ?? [];
+          for (const n of names) {
+            items.push({ name: n.replace(/^\//, ""), type: "container" });
+          }
+        }
+      } catch {
+        // Not in Docker Desktop or API unavailable
+      }
+
+      try {
+        const raw = await ddClient.docker.listImages();
+        const images = raw as ImageInfo[];
+        for (const img of images) {
+          const tags = img.RepoTags ?? [];
+          for (const tag of tags) {
+            if (tag !== "<none>:<none>") {
+              items.push({ name: tag, type: "image" });
+            }
+          }
+        }
+      } catch {
+        // Not in Docker Desktop or API unavailable
+      }
+
+      if (!cancelled) {
+        setResources(items);
+      }
+    }
+
+    fetchResources();
+    return () => {
+      cancelled = true;
+    };
+  }, [ddClient]);
+
+  return resources;
+}


### PR DESCRIPTION
## Summary
- Context-aware autocomplete in the command editor: suggests container names after `exec`/`start`/`stop` and image names after `run`/`pull`/`push`
- New `useDockerResources` hook fetches container/image lists from Extension SDK
- Keyboard navigation: Arrow keys, Tab/Enter to accept, Escape to dismiss
- Graceful degradation: empty suggestions when not in Docker Desktop

Closes #90

## Test plan
- [x] TypeScript compiles (`npx tsc --noEmit`)
- [x] ESLint passes on all modified files
- [x] 134 tests pass (2 new hook tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)