### PR TITLE
fix: ensure UI version display matches Docker image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # Build the React UI
 FROM --platform=$BUILDPLATFORM node:22-alpine AS ui-builder
+ARG VERSION=0.2.0
 WORKDIR /app
 COPY ui/package.json ui/package-lock.json* ./
 RUN npm ci
 COPY ui/ ./
-RUN npm run build
+RUN npm version "$VERSION" --no-git-tag-version --allow-same-version && npm run build
 
 # Final extension image
 FROM alpine:3.19


### PR DESCRIPTION
## Summary

- Pipes the `VERSION` build-arg into the ui-builder Docker stage so `package.json` is updated before `npm run build`
- Ensures the Vite-injected `__APP_VERSION__` always matches the OCI image label version
- Eliminates version drift between Docker image tags and the footer display

**Root cause:** The Dockerfile's `ARG VERSION` only set OCI labels. The `npm run build` read `package.json` directly, so pushing tag `v0.1.2` when `package.json` said `0.1.0` produced a mismatch (image labeled 0.1.2, UI displayed v0.1.0).

## Test plan

- [ ] `cd ui && npx tsc --noEmit` passes
- [ ] `cd ui && npx vitest run` passes (134 tests)
- [ ] `docker build --build-arg VERSION=9.9.9 -t test-version .` then inspect the built UI JS for `9.9.9` to confirm the version flows through

🤖 Generated with [Claude Code](https://claude.com/claude-code)