### PR TITLE
feat: auto-populate Docker resource dropdowns for parameter variables

### DIFF
--- a/ui/src/__tests__/useDockerResources.test.ts
+++ b/ui/src/__tests__/useDockerResources.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { useDockerResources } from "../hooks/useDockerResources";
+import { useDockerResources, getResourceTypeForVariable } from "../hooks/useDockerResources";
 
 vi.mock("../App", () => ({
   useDockerDesktopClient: vi.fn(() => ({
@@ -18,6 +18,21 @@ vi.mock("../App", () => ({
           { RepoTags: ["<none>:<none>"] },
         ]),
       ),
+      cli: {
+        exec: vi.fn((cmd: string) => {
+          if (cmd === "volume") {
+            return Promise.resolve({
+              stdout: '{"Name":"my-data"}\n{"Name":"pg-volume"}\n',
+            });
+          }
+          if (cmd === "network") {
+            return Promise.resolve({
+              stdout: '{"Name":"bridge"}\n{"Name":"my-network"}\n',
+            });
+          }
+          return Promise.resolve({ stdout: "" });
+        }),
+      },
     },
   })),
 }));
@@ -58,5 +73,54 @@ describe("useDockerResources", () => {
     for (const name of containerNames) {
       expect(name).not.toMatch(/^\//);
     }
+  });
+
+  it("fetches volumes and networks", async () => {
+    const { result } = renderHook(() => useDockerResources());
+
+    await waitFor(() => {
+      expect(result.current.some((r) => r.type === "volume")).toBe(true);
+    });
+
+    const volumes = result.current.filter((r) => r.type === "volume");
+    const networks = result.current.filter((r) => r.type === "network");
+
+    expect(volumes).toContainEqual({ name: "my-data", type: "volume" });
+    expect(volumes).toContainEqual({ name: "pg-volume", type: "volume" });
+    expect(networks).toContainEqual({ name: "bridge", type: "network" });
+    expect(networks).toContainEqual({ name: "my-network", type: "network" });
+  });
+});
+
+describe("getResourceTypeForVariable", () => {
+  it("maps container-related names", () => {
+    expect(getResourceTypeForVariable("container")).toBe("container");
+    expect(getResourceTypeForVariable("container_name")).toBe("container");
+    expect(getResourceTypeForVariable("my_container")).toBe("container");
+  });
+
+  it("maps image-related names", () => {
+    expect(getResourceTypeForVariable("image")).toBe("image");
+    expect(getResourceTypeForVariable("image_name")).toBe("image");
+    expect(getResourceTypeForVariable("base_image")).toBe("image");
+  });
+
+  it("maps volume-related names", () => {
+    expect(getResourceTypeForVariable("volume")).toBe("volume");
+    expect(getResourceTypeForVariable("volume_name")).toBe("volume");
+    expect(getResourceTypeForVariable("data_volume")).toBe("volume");
+  });
+
+  it("maps network-related names", () => {
+    expect(getResourceTypeForVariable("network")).toBe("network");
+    expect(getResourceTypeForVariable("network_name")).toBe("network");
+    expect(getResourceTypeForVariable("my_network")).toBe("network");
+  });
+
+  it("returns null for non-resource variable names", () => {
+    expect(getResourceTypeForVariable("lines")).toBeNull();
+    expect(getResourceTypeForVariable("tag")).toBeNull();
+    expect(getResourceTypeForVariable("port")).toBeNull();
+    expect(getResourceTypeForVariable("name")).toBeNull();
   });
 });

--- a/ui/src/components/ParameterInputDialog.tsx
+++ b/ui/src/components/ParameterInputDialog.tsx
@@ -7,12 +7,14 @@ import {
   Button,
   TextField,
   MenuItem,
+  Autocomplete,
   Stack,
   Box,
   Typography,
 } from "@mui/material";
 import type { Runbook } from "../types";
 import { parseVariables, substituteVariables } from "../utils/variables";
+import { useDockerResources, getResourceTypeForVariable } from "../hooks/useDockerResources";
 
 interface ParameterInputDialogProps {
   open: boolean;
@@ -23,6 +25,7 @@ interface ParameterInputDialogProps {
 
 export function ParameterInputDialog({ open, onClose, onRun, runbook }: ParameterInputDialogProps) {
   const variables = useMemo(() => parseVariables(runbook.commands), [runbook.commands]);
+  const dockerResources = useDockerResources();
 
   const [values, setValues] = useState<Record<string, string>>(() => {
     const init: Record<string, string> = {};
@@ -105,24 +108,53 @@ export function ParameterInputDialog({ open, onClose, onRun, runbook }: Paramete
               Variables
             </Typography>
             <Stack spacing={2}>
-              {variables.map((v) =>
-                v.options.length > 0 ? (
-                  <TextField
-                    key={v.name}
-                    select
-                    label={v.name}
-                    value={values[v.name] ?? ""}
-                    onChange={(e) => handleChange(v.name, e.target.value)}
-                    size="small"
-                    fullWidth
-                  >
-                    {v.options.map((opt) => (
-                      <MenuItem key={opt} value={opt}>
-                        {opt}
-                      </MenuItem>
-                    ))}
-                  </TextField>
-                ) : (
+              {variables.map((v) => {
+                const resourceType = getResourceTypeForVariable(v.name);
+                const suggestions = resourceType
+                  ? dockerResources.filter((r) => r.type === resourceType).map((r) => r.name)
+                  : [];
+
+                if (v.options.length > 0) {
+                  return (
+                    <TextField
+                      key={v.name}
+                      select
+                      label={v.name}
+                      value={values[v.name] ?? ""}
+                      onChange={(e) => handleChange(v.name, e.target.value)}
+                      size="small"
+                      fullWidth
+                    >
+                      {v.options.map((opt) => (
+                        <MenuItem key={opt} value={opt}>
+                          {opt}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  );
+                }
+
+                if (suggestions.length > 0) {
+                  return (
+                    <Autocomplete
+                      key={v.name}
+                      freeSolo
+                      options={suggestions}
+                      value={values[v.name] ?? ""}
+                      onInputChange={(_e, newValue) => handleChange(v.name, newValue)}
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label={v.name}
+                          size="small"
+                          placeholder={v.defaultValue || undefined}
+                        />
+                      )}
+                    />
+                  );
+                }
+
+                return (
                   <TextField
                     key={v.name}
                     label={v.name}
@@ -132,8 +164,8 @@ export function ParameterInputDialog({ open, onClose, onRun, runbook }: Paramete
                     fullWidth
                     placeholder={v.defaultValue || undefined}
                   />
-                ),
-              )}
+                );
+              })}
             </Stack>
           </Box>
         </Box>

--- a/ui/src/hooks/useDockerResources.ts
+++ b/ui/src/hooks/useDockerResources.ts
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
 import { useDockerDesktopClient } from "../App";
 
+export type DockerResourceType = "container" | "image" | "volume" | "network";
+
 export interface DockerResource {
   name: string;
-  type: "container" | "image";
+  type: DockerResourceType;
 }
 
 interface ContainerInfo {
@@ -12,6 +14,27 @@ interface ContainerInfo {
 
 interface ImageInfo {
   RepoTags?: string[];
+}
+
+interface VolumeInfo {
+  Name?: string;
+}
+
+interface NetworkInfo {
+  Name?: string;
+}
+
+/**
+ * Map a variable name to a Docker resource type for autocomplete suggestions.
+ * Returns null if the name doesn't match any known resource pattern.
+ */
+export function getResourceTypeForVariable(name: string): DockerResourceType | null {
+  const lower = name.toLowerCase();
+  if (lower.includes("container")) return "container";
+  if (lower.includes("image")) return "image";
+  if (lower.includes("volume")) return "volume";
+  if (lower.includes("network")) return "network";
+  return null;
 }
 
 export function useDockerResources(): DockerResource[] {
@@ -50,6 +73,32 @@ export function useDockerResources(): DockerResource[] {
         }
       } catch {
         // Not in Docker Desktop or API unavailable
+      }
+
+      try {
+        const result = await ddClient.docker.cli.exec("volume", ["ls", "--format", "json"]);
+        const lines = result.stdout.split("\n").filter(Boolean);
+        for (const line of lines) {
+          const vol = JSON.parse(line) as VolumeInfo;
+          if (vol.Name) {
+            items.push({ name: vol.Name, type: "volume" });
+          }
+        }
+      } catch {
+        // volume ls unavailable
+      }
+
+      try {
+        const result = await ddClient.docker.cli.exec("network", ["ls", "--format", "json"]);
+        const lines = result.stdout.split("\n").filter(Boolean);
+        for (const line of lines) {
+          const net = JSON.parse(line) as NetworkInfo;
+          if (net.Name) {
+            items.push({ name: net.Name, type: "network" });
+          }
+        }
+      } catch {
+        // network ls unavailable
       }
 
       if (!cancelled) {


### PR DESCRIPTION
## Summary

- Variables named `container`, `image`, `volume`, or `network` (or containing those words) now show an autocomplete dropdown populated from the Docker API
- Users can still type custom values (freeSolo mode) -- the dropdown is a convenience, not a constraint
- Extended `useDockerResources` hook to also fetch volumes (`docker volume ls`) and networks (`docker network ls`)
- Added `getResourceTypeForVariable()` utility for keyword-based variable name matching

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] 140 tests pass (6 new: volume/network fetch + variable name mapping)
- [ ] In Docker Desktop: create a runbook with `{{container}}` variable, verify dropdown shows running containers
- [ ] Verify `{{image}}`, `{{volume}}`, `{{network}}` variables also show relevant resources
- [ ] Verify non-resource variables like `{{lines}}` remain plain text fields
- [ ] Verify explicit options (`{{env|dev,staging,prod}}`) still use select dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)