### PR TITLE
chore: add reinstall-extension Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ install-extension: build-extension ## Install the extension
 update-extension: build-extension ## Update the extension
 	docker extension update $(IMAGE):$(TAG)
 
+reinstall-extension: build-extension ## Build, remove old, and install fresh
+	-docker extension rm $(IMAGE):$(TAG) 2>/dev/null
+	echo "y" | docker extension install $(IMAGE):$(TAG)
+
 remove-extension: ## Remove the extension
 	docker extension rm $(IMAGE):$(TAG)
 


### PR DESCRIPTION
## Summary

- Adds `make reinstall-extension` target that builds, removes old extension, and installs fresh in one command
- Handles the known issue where `docker extension update` fails after image rebuild (KG#39)
- The `-` prefix on the rm command ignores errors if extension isn't currently installed

## Test plan

- [ ] `make reinstall-extension` works when extension is already installed
- [ ] `make reinstall-extension` works when extension is not installed (first install)

Generated with [Claude Code](https://claude.com/claude-code)