### PR TITLE
fix: collapsed cards save space and version fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 IMAGE ?= herbhall/runbooks
 TAG ?= latest
-VERSION ?= $(shell node -p "require('./ui/package.json').version" 2>/dev/null || echo "0.1.0")
+VERSION ?= $(shell node -p "require('./ui/package.json').version" 2>/dev/null || echo "0.2.0")
 
 BUILDER = buildx-multi-arch
 

--- a/ui/src/components/RunbookList.tsx
+++ b/ui/src/components/RunbookList.tsx
@@ -42,6 +42,7 @@ const getLayoutSx = (mode: LayoutMode, compact: boolean) => {
     gridTemplateColumns: "repeat(auto-fill, minmax(340px, 1fr))",
     gap,
     alignContent: "start",
+    alignItems: "start",
   };
 };
 


### PR DESCRIPTION
## Summary
- Add `alignItems: "start"` to grid layout so collapsed cards shrink to their content height instead of stretching to match the tallest card in the row
- Update Makefile VERSION fallback from 0.1.0 to 0.2.0

## Test plan
- [ ] Collapse one card in grid view — it should shrink, not leave blank space
- [ ] Verify `make -n build-extension` shows VERSION=0.2.0
- [ ] Rebuild extension with `make reinstall-extension` and verify footer shows v0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)