### PR TITLE
fix: use simple release type for non-root package.json

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "node",
+      "release-type": "simple",
       "version-file": "VERSION",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,


### PR DESCRIPTION
## Summary

- release-please `node` type requires `package.json` at repo root, but ours is at `ui/package.json`
- Switch to `simple` type which uses the `VERSION` file as sole version source
- Fixes the `Missing required file: package.json` error on push to main

## Test plan

- [ ] Merge this PR and verify release-please workflow passes on the resulting push to main

Co-Authored-By: Claude <noreply@anthropic.com>