### PR TITLE
feat: add smart collection filters (#103)

### DIFF
--- a/ui/src/__tests__/smart-collections.test.ts
+++ b/ui/src/__tests__/smart-collections.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getExecutionCount, didLastRunFail, getHistory, getLastRun } from "../utils/execution-history";
+
+// We test the real functions against localStorage (jsdom provides it)
+beforeEach(() => {
+  localStorage.clear();
+});
+
+function seedHistory(runbookId: string, entries: Array<{ exitCode: number; timestamp?: string }>) {
+  const history = entries.map((e, i) => ({
+    timestamp: e.timestamp ?? new Date(Date.now() - i * 60000).toISOString(),
+    exitCode: e.exitCode,
+    duration: 1000,
+    commandCount: 1,
+    outputSnippet: "",
+  }));
+  // Save to the preferences store (same mechanism as real code)
+  const prefs = JSON.parse(localStorage.getItem("runbooks-prefs") ?? "{}");
+  prefs[`exec-history-${runbookId}`] = history;
+  localStorage.setItem("runbooks-prefs", JSON.stringify(prefs));
+}
+
+describe("getExecutionCount", () => {
+  it("returns 0 for runbook with no history", () => {
+    expect(getExecutionCount("no-history")).toBe(0);
+  });
+
+  it("returns correct count for runbook with history", () => {
+    seedHistory("rb-1", [{ exitCode: 0 }, { exitCode: 0 }, { exitCode: 1 }]);
+    expect(getExecutionCount("rb-1")).toBe(3);
+  });
+});
+
+describe("didLastRunFail", () => {
+  it("returns false for runbook with no history", () => {
+    expect(didLastRunFail("no-history")).toBe(false);
+  });
+
+  it("returns false when last run succeeded", () => {
+    seedHistory("rb-ok", [{ exitCode: 0 }, { exitCode: 1 }]);
+    expect(didLastRunFail("rb-ok")).toBe(false);
+  });
+
+  it("returns true when last run failed", () => {
+    seedHistory("rb-fail", [{ exitCode: 1 }, { exitCode: 0 }]);
+    expect(didLastRunFail("rb-fail")).toBe(true);
+  });
+
+  it("returns true for non-zero exit codes other than 1", () => {
+    seedHistory("rb-crash", [{ exitCode: 137 }]);
+    expect(didLastRunFail("rb-crash")).toBe(true);
+  });
+});
+
+describe("smart filter integration", () => {
+  it("getLastRun returns null for no history", () => {
+    expect(getLastRun("empty")).toBeNull();
+  });
+
+  it("getLastRun returns most recent entry", () => {
+    seedHistory("rb-recent", [
+      { exitCode: 0, timestamp: "2026-03-01T10:00:00Z" },
+      { exitCode: 1, timestamp: "2026-02-28T10:00:00Z" },
+    ]);
+    const last = getLastRun("rb-recent");
+    expect(last).not.toBeNull();
+    expect(last!.exitCode).toBe(0);
+    expect(last!.timestamp).toBe("2026-03-01T10:00:00Z");
+  });
+
+  it("getHistory returns all entries in order", () => {
+    seedHistory("rb-multi", [
+      { exitCode: 0, timestamp: "2026-03-01T10:00:00Z" },
+      { exitCode: 1, timestamp: "2026-02-28T10:00:00Z" },
+      { exitCode: 0, timestamp: "2026-02-27T10:00:00Z" },
+    ]);
+    const history = getHistory("rb-multi");
+    expect(history).toHaveLength(3);
+    expect(history[0].timestamp).toBe("2026-03-01T10:00:00Z");
+  });
+});

--- a/ui/src/components/RunbookList.tsx
+++ b/ui/src/components/RunbookList.tsx
@@ -27,8 +27,11 @@ import DensitySmallIcon from "@mui/icons-material/DensitySmall";
 import { useRunbooks } from "../context/RunbookContext";
 import { useCategories } from "../context/CategoryContext";
 import { loadPreference, savePreference } from "../storage";
-import { getLastRun } from "../utils/execution-history";
-import type { SortOption, LayoutMode, GroupMode, Runbook, Category } from "../types";
+import { getLastRun, getExecutionCount, didLastRunFail } from "../utils/execution-history";
+import type { SortOption, LayoutMode, GroupMode, SmartFilter, Runbook, Category } from "../types";
+import HistoryIcon from "@mui/icons-material/History";
+import TrendingUpIcon from "@mui/icons-material/TrendingUp";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import { RunbookCard } from "./RunbookCard";
 import { CategoryBadge } from "./CategoryBadge";
 
@@ -92,6 +95,11 @@ export function RunbookList() {
     () => new Set(loadPreference<string[]>("collapsedGroups", [])),
   );
   const [collapsedCards, setCollapsedCards] = useState<Record<string, boolean>>({});
+  const [smartFilter, setSmartFilter] = useState<SmartFilter>("none");
+
+  const toggleSmartFilter = (filter: SmartFilter) => {
+    setSmartFilter((prev) => (prev === filter ? "none" : filter));
+  };
 
   const categoryMap = useMemo(
     () => new Map(categories.map((c) => [c.id, c])),
@@ -105,10 +113,36 @@ export function RunbookList() {
     return runbooks.filter((r) => !r.id.startsWith("example-"));
   }, [runbooks, showExamples]);
 
+  const smartFiltered = useMemo(() => {
+    if (smartFilter === "none") return visibleRunbooks;
+
+    if (smartFilter === "recent") {
+      return visibleRunbooks
+        .filter((r) => getLastRun(r.id) !== null)
+        .sort((a, b) => {
+          const aLast = getLastRun(a.id)!;
+          const bLast = getLastRun(b.id)!;
+          return bLast.timestamp.localeCompare(aLast.timestamp);
+        });
+    }
+
+    if (smartFilter === "most-used") {
+      return visibleRunbooks
+        .filter((r) => getExecutionCount(r.id) > 0)
+        .sort((a, b) => getExecutionCount(b.id) - getExecutionCount(a.id));
+    }
+
+    if (smartFilter === "failed") {
+      return visibleRunbooks.filter((r) => didLastRunFail(r.id));
+    }
+
+    return visibleRunbooks;
+  }, [visibleRunbooks, smartFilter]);
+
   const filtered = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
-    if (!q) return visibleRunbooks;
-    return visibleRunbooks.filter(
+    if (!q) return smartFiltered;
+    return smartFiltered.filter(
       (r) =>
         r.name.toLowerCase().includes(q) ||
         r.description.toLowerCase().includes(q) ||
@@ -116,7 +150,7 @@ export function RunbookList() {
         r.commands.some((c) => c.toLowerCase().includes(q)) ||
         (r.categoryId && categoryMap.get(r.categoryId)?.name.toLowerCase().includes(q)),
     );
-  }, [visibleRunbooks, searchQuery, categoryMap]);
+  }, [smartFiltered, searchQuery, categoryMap]);
 
   const sorted = useMemo(() => {
     const arr = [...filtered];
@@ -382,6 +416,39 @@ export function RunbookList() {
         </Tooltip>
       </Stack>
 
+      {/* Smart filters */}
+      {visibleRunbooks.length > 0 && (
+        <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
+          <Chip
+            icon={<HistoryIcon />}
+            label="Recently Used"
+            size="small"
+            variant={smartFilter === "recent" ? "filled" : "outlined"}
+            color={smartFilter === "recent" ? "primary" : "default"}
+            onClick={() => toggleSmartFilter("recent")}
+            sx={{ cursor: "pointer" }}
+          />
+          <Chip
+            icon={<TrendingUpIcon />}
+            label="Most Used"
+            size="small"
+            variant={smartFilter === "most-used" ? "filled" : "outlined"}
+            color={smartFilter === "most-used" ? "primary" : "default"}
+            onClick={() => toggleSmartFilter("most-used")}
+            sx={{ cursor: "pointer" }}
+          />
+          <Chip
+            icon={<ErrorOutlineIcon />}
+            label="Failed Last Run"
+            size="small"
+            variant={smartFilter === "failed" ? "filled" : "outlined"}
+            color={smartFilter === "failed" ? "primary" : "default"}
+            onClick={() => toggleSmartFilter("failed")}
+            sx={{ cursor: "pointer" }}
+          />
+        </Stack>
+      )}
+
       {/* Content */}
       {pinSorted.all.length === 0 ? (
         <Box
@@ -393,7 +460,9 @@ export function RunbookList() {
           }}
         >
           <Typography color="text.secondary">
-            No runbooks match your search.
+            {smartFilter !== "none"
+              ? "No runbooks match this filter."
+              : "No runbooks match your search."}
           </Typography>
         </Box>
       ) : groups ? (

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -43,6 +43,8 @@ export interface Category {
 
 export type GroupMode = "none" | "tag" | "category";
 
+export type SmartFilter = "none" | "recent" | "most-used" | "failed";
+
 export interface GlobalVariable {
   id: string;
   name: string;

--- a/ui/src/utils/execution-history.ts
+++ b/ui/src/utils/execution-history.ts
@@ -43,3 +43,12 @@ export function formatTimeAgo(timestamp: string): string {
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
 }
+
+export function getExecutionCount(runbookId: string): number {
+  return getHistory(runbookId).length;
+}
+
+export function didLastRunFail(runbookId: string): boolean {
+  const last = getLastRun(runbookId);
+  return last !== null && last.exitCode !== 0;
+}


### PR DESCRIPTION
## Summary

- Adds smart filter chips (Recently Used, Most Used, Failed Last Run) above the runbook list
- Filters leverage the existing execution history system to surface relevant runbooks
- Clicking a chip toggles the filter on/off; active filter re-sorts by the relevant metric

### Changes
- **types.ts**: Added `SmartFilter` type
- **execution-history.ts**: Added `getExecutionCount()` and `didLastRunFail()` helpers
- **RunbookList.tsx**: Added filter chip bar and `smartFiltered` useMemo step in the pipeline
- **smart-collections.test.ts**: 9 new tests for helper functions and type behavior

Closes #103

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx eslint .` passes (0 errors)
- [x] `npx vitest run` passes (162 tests)
- [x] Pre-push hook passes (typecheck + lint + test + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)