### PR TITLE
chore(deps): pin Dependabot majors blocked by docker-mui-theme and typescript-eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,27 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+    ignore:
+      # Pinned by @docker/docker-mui-theme peer range (>=5.x.x <=6.x.x).
+      # Revisit when Docker publishes a theme supporting MUI v7+.
+      - dependency-name: "@mui/material"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@mui/icons-material"
+        update-types: ["version-update:semver-major"]
+      # Pinned by @docker/docker-mui-theme peer range (react ^17 || ^18).
+      # Revisit when Docker publishes a theme supporting React 19+.
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
+      # Pinned by typescript-eslint 8.x peer range (>=4.8.4 <6.0.0).
+      # Revisit once typescript-eslint v9 ships with TypeScript 6 support.
+      - dependency-name: "typescript"
+        versions: ["6.x"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

Adds `ignore` entries to `.github/dependabot.yml` for six packages that cannot currently accept major-version bumps on this repo. Each block documents the upstream peer-range that drives the pin so the gate can be revisited when those upstreams move.

Root causes (verified against CI ERESOLVE logs on the three blocked open PRs):

- **`@docker/docker-mui-theme@0.0.13`** declares peers
  - `@mui/material >=5.x.x <=6.x.x` — blocks `@mui/material` and `@mui/icons-material` majors (project KG#85 / CLAUDE.md MUI v5 constraint)
  - `react-dom ^17 || ^18` — blocks `react`, `react-dom`, `@types/react`, `@types/react-dom` majors
- **`typescript-eslint@8.x`** declares peer `typescript >=4.8.4 <6.0.0` — blocks `typescript` 6.x (revisit when moving to `typescript-eslint@9`)

Without these ignore rules, Dependabot recreates the same three unmergeable PRs every week (currently #182, #183, #184 — all failing at `npm ci`).

Existing open PRs (#182 react-dom, #183 @mui/material v9, #184 typescript 6) are left open intentionally as visible reminders that the upstreams are behind. This change only affects future PR creation.

## Test plan

- [x] `ignore` block is scoped to the `/ui` npm ecosystem only; `github-actions` ecosystem is untouched
- [x] `dependabot.yml` remains valid YAML (pre-push lint passed)
- [ ] Next Monday's Dependabot run produces no new PRs for the pinned ranges (verify on first weekly trigger after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)